### PR TITLE
CI: use epsilon 10^-6 for gdxdiff comparison

### DIFF
--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -102,6 +102,7 @@ def run_gams_gdxdiff(
             path.join(dd_folder, "scenario.gdx"),
             path.join(out_folder, "scenario.gdx"),
             path.join(out_folder, "diffile.gdx"),
+            "Eps=0.000001",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
Demo 2 and 3 have spurious non-OK gdxdiff output, due to floating point errors. This PR uses a 10^-6 epsilon, under which they match 100%.