### PR TITLE
Remove rows with duplicate query cols and cleanup handling of TFM variants

### DIFF
--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -196,11 +196,6 @@ def compare(
                     f" {data_cols}, should be {transformed_gt_cols}"
                 )
 
-            # Remove duplicate rows from ground truth
-            # For parameters, ignore VALUE col when computing dupilcates
-            query_columns = [c for c in gt_table.columns if c != "VALUE"] or None
-            gt_table = gt_table.drop_duplicates(subset=query_columns, keep="last")
-
             # both are in string form so can be compared without any issues
             gt_rows = set(tuple(row) for row in gt_table.to_numpy().tolist())
             data_rows = set(tuple(row) for row in data_table.to_numpy().tolist())

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -277,8 +277,9 @@ def produce_times_tables(
                 for times_col, xl_col in mapping.col_map.items():
                     df[times_col] = df[xl_col]
                 cols_to_drop = [x for x in df.columns if not x in mapping.times_cols]
-                df = df.drop(columns=cols_to_drop)
-                # Remove rows with NA values
+                df.drop(columns=cols_to_drop, inplace=True)
+                df.drop_duplicates(inplace=True)
+                df.reset_index(drop=True, inplace=True)
                 # TODO this is a hack. Use pd.StringDtype() so that notna() is sufficient
                 i = (
                     df[mapping.times_cols[-1]].notna()
@@ -287,10 +288,6 @@ def produce_times_tables(
                     & (df != "").all(axis=1)
                 )
                 df = df.loc[i, mapping.times_cols]
-                # Remove duplicate rows. For parameters, remove rows with duplicate query cols
-                query_columns = [c for c in df.columns if c != "VALUE"] or None
-                df = df.drop_duplicates(subset=query_columns, keep="last")
-                df = df.reset_index(drop=True)
                 # Drop tables that are empty after filtering and dropping Nones:
                 if len(df) == 0:
                     continue

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -317,6 +317,9 @@ def write_dd_files(
     def convert_parameter(tablename: str, df: DataFrame):
         if "VALUE" not in df.columns:
             raise KeyError(f"Unable to find VALUE column in parameter {tablename}")
+        # Remove duplicate rows, ignoring value column
+        query_columns = [c for c in df.columns if c != "VALUE"] or None
+        df = df.drop_duplicates(subset=query_columns, keep="last")
         for row in df.itertuples(index=False):
             val = row.VALUE
             row_str = "'.'".join(

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -273,9 +273,8 @@ def produce_times_tables(
                 for times_col, xl_col in mapping.col_map.items():
                     df[times_col] = df[xl_col]
                 cols_to_drop = [x for x in df.columns if not x in mapping.times_cols]
-                df.drop(columns=cols_to_drop, inplace=True)
-                df.drop_duplicates(inplace=True)
-                df.reset_index(drop=True, inplace=True)
+                df = df.drop(columns=cols_to_drop)
+                # Remove rows with NA values
                 # TODO this is a hack. Use pd.StringDtype() so that notna() is sufficient
                 i = (
                     df[mapping.times_cols[-1]].notna()
@@ -284,6 +283,10 @@ def produce_times_tables(
                     & (df != "").all(axis=1)
                 )
                 df = df.loc[i, mapping.times_cols]
+                # Remove duplicate rows. For parameters, remove rows with duplicate query cols
+                query_columns = [c for c in df.columns if c != "VALUE"] or None
+                df = df.drop_duplicates(subset=query_columns, keep="last")
+                df = df.reset_index(drop=True)
                 # Drop tables that are empty after filtering and dropping Nones:
                 if len(df) == 0:
                     continue

--- a/xl2times/config/veda-tags.json
+++ b/xl2times/config/veda-tags.json
@@ -1667,11 +1667,7 @@
   {
     "tag_name": "tfm_ins-txt",
     "tag_allowed_in": [
-      "BY_Trans",
-      "SR_Trans",
-      "SysSettings",
-      "RegScen",
-      "TradeScen"
+      "SysSettings"
     ],
     "base_tag": "tfm_ins",
     "mod_type": "ts"

--- a/xl2times/config/veda-tags.json
+++ b/xl2times/config/veda-tags.json
@@ -1665,6 +1665,18 @@
     "mod_type": "tsl"
   },
   {
+    "tag_name": "tfm_ins-txt",
+    "tag_allowed_in": [
+      "BY_Trans",
+      "SR_Trans",
+      "SysSettings",
+      "RegScen",
+      "TradeScen"
+    ],
+    "base_tag": "tfm_ins",
+    "mod_type": "ts"
+  },
+  {
     "tag_name": "tfm_mig",
     "tag_allowed_in": [
       "BY_Trans",

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -406,6 +406,8 @@ class Config:
                     discard_if_empty.append(tag_name)
                 if base_tag in row_comment_chars:
                     row_comment_chars[tag_name] = row_comment_chars[base_tag]
+                if base_tag in known_cols:
+                    known_cols[tag_name] = known_cols[base_tag]
 
         return valid_column_names, row_comment_chars, discard_if_empty, known_cols
 

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1594,12 +1594,7 @@ def process_transform_tables(
             df = table.dataframe.copy()
 
             # Standardize column names
-            known_columns = config.known_columns[datatypes.Tag.tfm_ins] | query_columns
-            if table.tag == datatypes.Tag.tfm_mig:
-                # Also allow attribute2, year2 etc for TFM_MIG tables
-                known_columns.update(
-                    (c + "2" for c in config.known_columns[datatypes.Tag.tfm_ins])
-                )
+            known_columns = config.known_columns[table.tag] | query_columns
 
             # Handle Regions:
             if set(df.columns).isdisjoint(

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1282,7 +1282,6 @@ def process_years(
     tables: Dict[str, DataFrame],
     model: datatypes.TimesModel,
 ) -> Dict[str, DataFrame]:
-
     # Datayears is the set of all years in ~FI_T's Year column
     # We ignore values < 1000 because those signify interpolation/extrapolation rules
     # (see Table 8 of Part IV of the Times Documentation)
@@ -1860,8 +1859,6 @@ def process_wildcards(
 ) -> Dict[str, DataFrame]:
     topology = generate_topology_dictionary(tables, model)
 
-    # TODO add type annots to below fns
-
     def match_wildcards(
         row: pd.Series,
     ) -> tuple[DataFrame | None, DataFrame | None] | None:
@@ -1875,7 +1872,13 @@ def process_wildcards(
             return None
         return matching_processes, matching_commodities
 
-    def query(table, processes, commodities, attribute, region):
+    def query(
+        table: DataFrame,
+        processes: DataFrame | None,
+        commodities: DataFrame | None,
+        attribute: str | None,
+        region: str | None,
+    ) -> pd.Index:
         qs = []
         if processes is not None and not processes.empty:
             qs.append(f"process in [{','.join(map(repr, processes['process']))}]")
@@ -1887,7 +1890,9 @@ def process_wildcards(
             qs.append(f"region == '{region}'")
         return table.query(" and ".join(qs)).index
 
-    def eval_and_update(table, rows_to_update, new_value):
+    def eval_and_update(
+        table: DataFrame, rows_to_update: pd.Index, new_value: str
+    ) -> None:
         if isinstance(new_value, str) and new_value[0] in {"*", "+", "-", "/"}:
             old_values = table.loc[rows_to_update, "value"]
             updated = old_values.astype(float).map(lambda x: eval("x" + new_value))

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1868,7 +1868,7 @@ def process_wildcards(
             matching_commodities is None or len(matching_commodities) == 0
         ):  # TODO is this necessary? Try without?
             # TODO debug these
-            print(f"WARNING: a row matched no processes or commodities:\n{row}")
+            print(f"WARNING: a row matched no processes or commodities")
             return None
         return matching_processes, matching_commodities
 
@@ -1893,46 +1893,14 @@ def process_wildcards(
     def eval_and_update(
         table: DataFrame, rows_to_update: pd.Index, new_value: str
     ) -> None:
+        """Performs an inplace update of rows `rows_to_update` of `table` with `new_value`,
+        which can be a update formula like `*2.3`."""
         if isinstance(new_value, str) and new_value[0] in {"*", "+", "-", "/"}:
             old_values = table.loc[rows_to_update, "value"]
             updated = old_values.astype(float).map(lambda x: eval("x" + new_value))
             table.loc[rows_to_update, "value"] = updated
         else:
             table.loc[rows_to_update, "value"] = new_value
-
-    def do_an_ins_row(row):
-        table = tables[datatypes.Tag.fi_t]
-        match = match_wildcards(row)
-        # TODO perf: add matched procs/comms into column and use explode?
-        new_rows = pd.DataFrame([row.filter(table.columns)])
-        if match is not None:
-            processes, commodities = match
-            if processes is not None:
-                new_rows = processes.merge(new_rows, how="cross")
-            if commodities is not None:
-                new_rows = commodities.merge(new_rows, how="cross")
-        return new_rows
-
-    def do_an_ins_txt_row(row):
-        match = match_wildcards(row)
-        if match is None:
-            print(f"WARNING: TFM_INS-TXT row matched neither commodity nor process")
-            return
-        processes, commodities = match
-        if commodities is not None:
-            table = model.commodities
-        elif processes is not None:
-            table = model.processes
-        else:
-            assert False  # All rows match either a commodity or a process
-
-        # Query for rows with matching process/commodity and region
-        rows_to_update = query(table, processes, commodities, None, row["region"])
-        # Overwrite (inplace) the column given by the attribute (translated by attr_prop)
-        # with the value from row
-        # E.g. if row['attribute'] == 'PRC_TSL' then we overwrite 'tslvl'
-        table.loc[rows_to_update, attr_prop[row["attribute"]]] = row["value"]
-        # return rows_to_update
 
     if datatypes.Tag.tfm_upd in tables:
         updates = tables[datatypes.Tag.tfm_upd]
@@ -1941,6 +1909,8 @@ def process_wildcards(
         # Reset FI_T index so that queries can determine unique rows to update
         tables[datatypes.Tag.fi_t].reset_index(inplace=True)
 
+        # TFM_UPD: expand wildcards in each row, query FI_T to find matching rows,
+        # evaluate the update formula, and add new rows to FI_T
         # TODO perf: collect all updates and go through FI_T only once?
         for _, row in updates.iterrows():
             if row["value"] is None:  # TODO is this really needed?
@@ -1961,16 +1931,49 @@ def process_wildcards(
 
     if datatypes.Tag.tfm_ins in tables:
         updates = tables[datatypes.Tag.tfm_ins]
-        new_rows = []
+        table = tables[datatypes.Tag.fi_t]
+        new_tables = []
+
+        # TFM_INS: expand each row by wildcards, then add to FI_T
         for _, row in updates.iterrows():
-            new_rows.append(do_an_ins_row(row))
-        new_rows.append(tables[datatypes.Tag.fi_t])
-        tables[datatypes.Tag.fi_t] = pd.concat(new_rows, ignore_index=True)
+            match = match_wildcards(row)
+            # TODO perf: add matched procs/comms into column and use explode?
+            new_rows = pd.DataFrame([row.filter(table.columns)])
+            if match is not None:
+                processes, commodities = match
+                if processes is not None:
+                    new_rows = processes.merge(new_rows, how="cross")
+                if commodities is not None:
+                    new_rows = commodities.merge(new_rows, how="cross")
+            new_tables.append(new_rows)
+
+        new_tables.append(tables[datatypes.Tag.fi_t])
+        tables[datatypes.Tag.fi_t] = pd.concat(new_tables, ignore_index=True)
 
     if datatypes.Tag.tfm_ins_txt in tables:
         updates = tables[datatypes.Tag.tfm_ins_txt]
+
+        # TFM_INS-TXT: expand row by wildcards, query FI_PROC/COMM for matching rows,
+        # evaluate the update formula, and inplace update the rows
         for _, row in updates.iterrows():
-            do_an_ins_txt_row(row)
+            match = match_wildcards(row)
+            if match is None:
+                print(f"WARNING: TFM_INS-TXT row matched neither commodity nor process")
+                continue
+            processes, commodities = match
+            if commodities is not None:
+                table = model.commodities
+            elif processes is not None:
+                table = model.processes
+            else:
+                assert False  # All rows match either a commodity or a process
+
+            # Query for rows with matching process/commodity and region
+            rows_to_update = query(table, processes, commodities, None, row["region"])
+            # Overwrite (inplace) the column given by the attribute (translated by attr_prop)
+            # with the value from row
+            # E.g. if row['attribute'] == 'PRC_TSL' then we overwrite 'tslvl'
+            table.loc[rows_to_update, attr_prop[row["attribute"]]] = row["value"]
 
     if datatypes.Tag.tfm_mig in tables:
         updates = tables[datatypes.Tag.tfm_mig]


### PR DESCRIPTION
This PR makes the following changes:
- It implements the [suggestion](https://github.com/etsap-TIMES/xl2times/pull/166#discussion_r1466952849) of using `Config.known_columns` of the table's tag instead of always using that of TFM_INS.
- It adds `TFM_INS-TXT` to `veda-tags.json` and modifies `Config` to use the base tag's known columns if none is specified. (These two changes correspond to the first 3 commits, and introduce no regression.)
- It removes rows with duplicate query columns (for GAMS parameters), which is [needed]( https://github.com/etsap-TIMES/xl2times/pull/166#issuecomment-1918683939 ) because #166 changed the behaviour of TFM_UPD to add new rows instead of updating rows inplace.
- However, this leads to a regression of correct rows, because for example in Demo 9 the ground truth DD repo has COM_PROJ defined in multiple files, with files having duplicate rows (when considering only query columns). So `dd_to_csv.py` is producing a CSV file for COM_PROJ that has duplicate rows, whereas we now only keep the last row in our output.
- I tried to resolve the above regression by modifying the ground truth comparison code to first remove duplicates in the ground truth before comparing. I then manually checked that the benchmarks that continue to regress only do so because additional rows or ground truth rows reduced, and not because missing rows increased.

However, Ireland has new missing rows:
![image](https://github.com/etsap-TIMES/xl2times/assets/10712637/b3648600-8a81-4404-93e7-bb16918c273d)

I looked into the new missing rows in ACT_EFF in Ireland:
![image](https://github.com/etsap-TIMES/xl2times/assets/10712637/d0ccd11e-7152-4a97-a49f-2fc0623d904d)
![image](https://github.com/etsap-TIMES/xl2times/assets/10712637/478594b3-1496-4016-a6de-44fbb5c825ba)

It looks like the problem is that the order in which `dd_to_csv.py` reads DD files puts the `1` row last, while we produce  the `1.075` row last. Perhaps we need to add the DD file order to `benchmarks.yml` so that we read DD files in the same order that GAMS will?