### PR TITLE
CI: fix bug in parsing additional lines

### DIFF
--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -36,7 +36,7 @@ def parse_result(output: str) -> Tuple[float, int, int]:
         sys.exit(2)
     # return (accuracy, num_correct_rows, num_additional_rows)
     m = m[0]
-    return (float(m[0]), int(m[1]), int(m[2]))
+    return (float(m[0]), int(m[1]), int(m[3]))
 
 
 def run_gams_gdxdiff(


### PR DESCRIPTION
Fixes a bug in the parsing of additional lines by the regression tests introduced in #190:
https://github.com/etsap-TIMES/xl2times/pull/190/files#diff-cca48a967a9c20b6fc94f3c37310d00cd4c05e08fea487fafe27ab770590ec2bR38

Which causes the test to use the total lines as additional lines:
<img width="900" alt="image" src="https://github.com/etsap-TIMES/xl2times/assets/10712637/18387688-950c-4b06-a61d-9a6175ed1a0d">

