### PR TITLE
Allow processing of duplicated attribute data columns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       PY_VERSION: "3.11"
       REF_TIMES_model: "b488fb07f0899ee8b7e710c230b1a9414fa06f7d"
-      REF_demos-xlsx: "f956db07a253d4f5c60e108791ab7bb2b8136690"
+      REF_demos-xlsx: "34a2a5c044cc0bbea1357de50db2f5f02d575181"
       REF_demos-dd: "2848a8a8e2fdcf0cdf7f83eefbdd563b0bb74e86"
       REF_tim: "e820d8002adc6b1526a3bffcc439219b28d0eed5"
       REF_tim-gams: "703f6a4e1d0bedd95c3ebdae534496f3a7e1b7cc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       PY_VERSION: "3.11"
       REF_TIMES_model: "b488fb07f0899ee8b7e710c230b1a9414fa06f7d"
-      REF_demos-xlsx: "34a2a5c044cc0bbea1357de50db2f5f02d575181"
+      REF_demos-xlsx: "f956db07a253d4f5c60e108791ab7bb2b8136690"
       REF_demos-dd: "2848a8a8e2fdcf0cdf7f83eefbdd563b0bb74e86"
       REF_tim: "e820d8002adc6b1526a3bffcc439219b28d0eed5"
       REF_tim-gams: "703f6a4e1d0bedd95c3ebdae534496f3a7e1b7cc"

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2622,14 +2622,6 @@ def convert_aliases(
             df.replace({"attribute": replacement_dict}, inplace=True)
         tables[table_type] = df
 
-    # Drop duplicates generated due to renaming
-    # TODO: Clear values in irrelevant columns before doing this
-    # TODO: Do this comprehensively for all relevant tables
-    df = tables[datatypes.Tag.fi_t]
-    df = df.dropna(subset="value").drop_duplicates(
-        subset=[col for col in df.columns if col != "value"], keep="last"
-    )
-    tables[datatypes.Tag.fi_t] = df.reset_index(drop=True)
     # TODO: do this earlier
     model.attributes = tables[datatypes.Tag.fi_t]
     if datatypes.Tag.uc_t in tables.keys():

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2610,6 +2610,14 @@ def convert_aliases(
             df.replace({"attribute": replacement_dict}, inplace=True)
         tables[table_type] = df
 
+    # Drop duplicates generated due to renaming
+    # TODO: Clear values in irrelevant columns before doing this
+    # TODO: Do this comprehensively for all relevant tables
+    df = tables[datatypes.Tag.fi_t]
+    df = df.dropna(subset="value").drop_duplicates(
+        subset=[col for col in df.columns if col != "value"], keep="last"
+    )
+    tables[datatypes.Tag.fi_t] = df.reset_index(drop=True)
     # TODO: do this earlier
     model.attributes = tables[datatypes.Tag.fi_t]
     if datatypes.Tag.uc_t in tables.keys():

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -456,6 +456,7 @@ def process_flexible_import_tables(
         known_columns = config.known_columns[datatypes.Tag.fi_t]
         data_columns = [x for x in df.columns if x not in known_columns]
 
+        # TODO: Replace this with something similar to know columns from config
         # Populate index columns
         index_columns = [
             "region",

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -60,7 +60,14 @@ def explode(df, data_columns):
     :return:                Tuple with the exploded dataframe and a Series of the original
                             column name for each value in each new row.
     """
-    data = df[data_columns].values.tolist()
+    # Handle duplicate columns (https://pandas.pydata.org/docs/user_guide/duplicates.html)
+    if len(set(data_columns)) < len(data_columns):
+        cols = df.columns.to_list()
+        data_cols_idx = [idx for idx, val in enumerate(cols) if val in data_columns]
+        data = df.iloc[:, data_cols_idx].values.tolist()
+    else:
+        data = df[data_columns].values.tolist()
+
     other_columns = [
         colname for colname in df.columns.values if colname not in data_columns
     ]
@@ -69,7 +76,6 @@ def explode(df, data_columns):
     df = df.assign(value=data)
     nrows = df.shape[0]
     df = df.explode(value_column, ignore_index=True)
-
     names = pd.Series(data_columns * nrows, index=df.index, dtype=str)
     # Remove rows with no VALUE
     index = df[value_column].notna()


### PR DESCRIPTION
Implications of duplicate labels for operations in pandas are described here: https://pandas.pydata.org/docs/user_guide/duplicates.html#consequences-of-duplicate-labels

This PR ensures the data in a duplicated column is returned only once (and not e.g. twice if 2 columns with the same name are present) during processing.