### PR TITLE
Update Demos version used in benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       PY_VERSION: "3.11"
       REF_TIMES_model: "b488fb07f0899ee8b7e710c230b1a9414fa06f7d"
-      REF_demos-xlsx: "f956db07a253d4f5c60e108791ab7bb2b8136690"
+      REF_demos-xlsx: "34a2a5c044cc0bbea1357de50db2f5f02d575181"
       REF_demos-dd: "2848a8a8e2fdcf0cdf7f83eefbdd563b0bb74e86"
       REF_tim: "e820d8002adc6b1526a3bffcc439219b28d0eed5"
       REF_tim-gams: "703f6a4e1d0bedd95c3ebdae534496f3a7e1b7cc"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,33 +29,51 @@ class TestUtils:
         data_cols1 = ["act_bnd", "actbnd", "act_bnd"]
         data_cols2 = ["act_bnd", "actbnd"]
 
-        correct_result1 = pd.DataFrame(
-            [
-                ("PRC1", "act_bnd", 100),
-                ("PRC1", "act_bnd", 200),
-                ("PRC2", "act_bnd", 100),
-                ("PRC2", "actbnd", 150),
-                ("PRC3", "actbnd", 150),
-                ("PRC3", "act_bnd", 200),
-            ],
-            columns=["process", "attribute", "value"],
+        correct_index1 = [0, 2, 3, 4, 7, 8]
+        correct_index2 = [0, 2, 3, 5]
+
+        correct_result1 = (
+            pd.DataFrame(
+                [
+                    ("PRC1", 100),
+                    ("PRC1", 200),
+                    ("PRC2", 100),
+                    ("PRC2", 150),
+                    ("PRC3", 150),
+                    ("PRC3", 200),
+                ],
+                columns=["process", "value"],
+                index=correct_index1,
+                dtype=object,
+            ),
+            pd.Series(
+                ["act_bnd", "act_bnd", "act_bnd", "actbnd", "actbnd", "act_bnd"],
+                index=correct_index1,
+            ),
         )
 
-        correct_result2 = pd.DataFrame(
-            [
-                ("PRC1", "act_bnd", 100),
-                ("PRC2", "act_bnd", 100),
-                ("PRC2", "actbnd", 150),
-                ("PRC3", "actbnd", 150),
-            ],
-            columns=["process", "attribute", "value"],
+        correct_result2 = (
+            pd.DataFrame(
+                [
+                    ("PRC1", 100),
+                    ("PRC2", 100),
+                    ("PRC2", 150),
+                    ("PRC3", 150),
+                ],
+                columns=["process", "value"],
+                index=correct_index2,
+                dtype=object,
+            ),
+            pd.Series(["act_bnd", "act_bnd", "actbnd", "actbnd"], index=correct_index2),
         )
 
-        output_df1, _ = utils.explode(input_df1, data_cols1)
-        output_df2, _ = utils.explode(input_df2, data_cols2)
+        output1 = utils.explode(input_df1, data_cols1)
+        output2 = utils.explode(input_df2, data_cols2)
 
-        assert output_df1.equals(correct_result1), "Dataframes should be equal"
-        assert output_df2.equals(correct_result2), "Dataframes should be equal"
+        assert output1[0].equals(correct_result1[0]), "Dataframes should be equal"
+        assert output1[1].equals(correct_result1[1]), "Series should be equal"
+        assert output2[0].equals(correct_result2[0]), "Dataframes should be equal"
+        assert output2[1].equals(correct_result2[1]), "Series should be equal"
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,62 @@
+from xl2times import utils
+import pandas as pd
+
+
+class TestUtils:
+    def test_explode(self):
+        """
+        Test that explode logics functions correctly
+        """
+
+        input_df1 = pd.DataFrame(
+            [
+                ("PRC1", 100, None, 200),
+                ("PRC2", 100, 150, None),
+                ("PRC3", None, 150, 200),
+            ],
+            columns=["process", "act_bnd", "actbnd", "act_bnd"],
+        )
+
+        input_df2 = pd.DataFrame(
+            [
+                ("PRC1", 100, None),
+                ("PRC2", 100, 150),
+                ("PRC3", None, 150),
+            ],
+            columns=["process", "act_bnd", "actbnd"],
+        )
+
+        data_cols1 = ["act_bnd", "actbnd", "act_bnd"]
+        data_cols2 = ["act_bnd", "actbnd"]
+
+        correct_result1 = pd.DataFrame(
+            [
+                ("PRC1", "act_bnd", 100),
+                ("PRC1", "act_bnd", 200),
+                ("PRC2", "act_bnd", 100),
+                ("PRC2", "actbnd", 150),
+                ("PRC3", "actbnd", 150),
+                ("PRC3", "act_bnd", 200),
+            ],
+            columns=["process", "attribute", "value"],
+        )
+
+        correct_result2 = pd.DataFrame(
+            [
+                ("PRC1", "act_bnd", 100),
+                ("PRC2", "act_bnd", 100),
+                ("PRC2", "actbnd", 150),
+                ("PRC3", "actbnd", 150),
+            ],
+            columns=["process", "attribute", "value"],
+        )
+
+        output_df1, _ = utils.explode(input_df1, data_cols1)
+        output_df2, _ = utils.explode(input_df2, data_cols2)
+
+        assert output_df1.equals(correct_result1), "Dataframes should be equal"
+        assert output_df2.equals(correct_result2), "Dataframes should be equal"
+
+
+if __name__ == "__main__":
+    TestUtils().test_explode()

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -93,6 +93,7 @@ def convert_xl_to_times(
         transforms.remove_comment_rows,
         transforms.revalidate_input_tables,
         transforms.process_regions,
+        transforms.process_time_periods,
         transforms.remove_exreg_cols,
         transforms.generate_dummy_processes,
         transforms.process_time_slices,
@@ -110,7 +111,6 @@ def convert_xl_to_times(
         transforms.fill_in_missing_values,
         transforms.expand_rows_parallel,  # slow
         transforms.remove_invalid_values,
-        transforms.process_time_periods,
         transforms.capitalise_some_values,
         transforms.apply_fixups,
         transforms.generate_commodity_groups,

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -105,10 +105,10 @@ def convert_xl_to_times(
         transforms.process_flexible_import_tables,  # slow
         transforms.process_user_constraint_tables,
         transforms.process_commodity_emissions,
-        transforms.generate_uc_properties,
         transforms.process_commodities,
         transforms.process_transform_availability,
         transforms.fill_in_missing_values,
+        transforms.generate_uc_properties,
         transforms.expand_rows_parallel,  # slow
         transforms.remove_invalid_values,
         transforms.capitalise_some_values,

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2352,6 +2352,7 @@ def process_wildcards(
                 table, processes, commodities, row["attribute"], row["region"]
             )
             new_rows = table.loc[rows_to_update].copy()
+            new_rows["source_filename"] = row["source_filename"]
             eval_and_update(new_rows, rows_to_update, row["value"])
             new_tables.append(new_rows)
 
@@ -2378,6 +2379,7 @@ def process_wildcards(
                     new_rows = processes.merge(new_rows, how="cross")
                 if commodities is not None:
                     new_rows = commodities.merge(new_rows, how="cross")
+            new_rows["source_filename"] = row["source_filename"]
             new_tables.append(new_rows)
 
         new_tables.append(tables[datatypes.Tag.fi_t])
@@ -2435,6 +2437,7 @@ def process_wildcards(
                     new_rows.loc[:, c[:-1]] = v
             # Evaluate 'value' column based on existing values
             eval_and_update(new_rows, rows_to_update, row["value"])
+            new_rows["source_filename"] = row["source_filename"]
             new_tables.append(new_rows)
 
         # Add new rows to table

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -749,7 +749,7 @@ def generate_uc_properties(
         # Handle allregions by substituting it with a list of internal regions
         index = user_constraints["region"].str.lower() == "allregions"
         if any(index):
-            user_constraints.loc[index, ["region"]] = list(model.internal_regions)
+            user_constraints.loc[index, ["region"]] = ",".join(model.internal_regions)
 
         # Handle comma-separated regions
         index = user_constraints["region"].str.contains(",")

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2622,6 +2622,14 @@ def convert_aliases(
             df.replace({"attribute": replacement_dict}, inplace=True)
         tables[table_type] = df
 
+    # Drop duplicates generated due to renaming
+    # TODO: Clear values in irrelevant columns before doing this
+    # TODO: Do this comprehensively for all relevant tables
+    df = tables[datatypes.Tag.fi_t]
+    df = df.dropna(subset="value").drop_duplicates(
+        subset=[col for col in df.columns if col != "value"], keep="last"
+    )
+    tables[datatypes.Tag.fi_t] = df.reset_index(drop=True)
     # TODO: do this earlier
     model.attributes = tables[datatypes.Tag.fi_t]
     if datatypes.Tag.uc_t in tables.keys():

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -665,7 +665,7 @@ def process_user_constraint_tables(
                     set(regions.upper().split(","))
                 )
                 regions = ",".join(regions)
-                df["region"] = df["region"].fillna(regions)
+                df.loc[df["region"].isna(), ["region"]] = regions
 
         # TODO: detect RHS correctly
         i = df["side"].isna()
@@ -741,18 +741,20 @@ def generate_uc_properties(
         # Use name to populate description if it is missing
         index = user_constraints["description"].isna()
         if any(index):
-            user_constraints["description"][index] = user_constraints["uc_n"][index]
+            user_constraints.loc[index, ["description"]] = user_constraints["uc_n"][
+                index
+            ]
 
         # TODO: Can this (until user_constraints.explode) become a utility function?
         # Handle allregions by substituting it with a list of internal regions
         index = user_constraints["region"].str.lower() == "allregions"
         if any(index):
-            user_constraints["region"][index] = [model.internal_regions]
+            user_constraints.loc[index, ["region"]] = list(model.internal_regions)
 
         # Handle comma-separated regions
-        index = user_constraints["region"].str.contains(",").fillna(value=False)
+        index = user_constraints["region"].str.contains(",")
         if any(index):
-            user_constraints["region"][index] = user_constraints.apply(
+            user_constraints.loc[index, ["region"]] = user_constraints.apply(
                 lambda row: [
                     region
                     for region in str(row["region"]).split(",")

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -181,7 +181,7 @@ def missing_value_inherit(df: DataFrame, colname: str):
 
 
 def get_scalar(table_tag: str, tables: List[datatypes.EmbeddedXlTable]):
-    table = next(filter(lambda t: t.tag == table_tag, tables))
+    table = one(filter(lambda t: t.tag == table_tag, tables))
     if table.dataframe.shape[0] != 1 or table.dataframe.shape[1] != 1:
         raise ValueError("Not scalar table")
     return table.dataframe["value"].values[0]


### PR DESCRIPTION
This PR updates version of Demos used for benchmarks and adds a unit test to test processing of the variation introduced by the update. 
Due to the update, it also:
- drops duplicate rows after alias conversion;
- adds source file info to records generated by `TFM` tables (to facilitate the above);
- adds `year` as a query parameter when processing `TFM_UPD` and `TFM_MIG` tables.

This PR also includes minor code refactoring to address pandas depreciation warnings.