### PR TITLE
Add release instructions and CD automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,25 @@ jobs:
         with:
           python-version: ${{ env.PY_VERSION }}
 
-      - name: Check code formatting
-        working-directory: xl2times
-        run: |
-          python -m pip install --upgrade pre-commit
-          pre-commit install
-          pre-commit run --all-files
-
       - name: Build and install xl2times
         working-directory: xl2times
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          python -m pip install --upgrade pip build twine
+          python -m pip install --upgrade pip build
           rm -rf dist || true
           python -m build
           # Install the built wheel file to imitiate users installing from PyPI:
           python -m pip install --no-index --find-links=dist xl2times
+
+      - name: Check code formatting
+        working-directory: xl2times
+        # Run this step after install so that pyright can find dependencies like pandas
+        run: |
+          source .venv/bin/activate
+          python -m pip install --upgrade pre-commit
+          pre-commit install
+          pre-commit run --all-files
 
       - name: Run unit tests
         working-directory: xl2times

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,20 @@ jobs:
         with:
           path: ~/.cache/xl2times
           key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
+
+      # ---------- Build package and upload to PyPI
+
+      - name: Build package
+        working-directory: xl2times
+        run: |
+          source .venv/bin/activate
+          python -m pip install --upgrade build twine
+          rm -rf dist || true
+          python -m build
+
+      - name: Download dist built by CI job
+        # if: startsWith(github.ref, 'refs/tags/v') # Only run on tags `v...`
+        # if: github.event_name == 'release' && github.event.action == 'created'  # TODO use this before merge
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,20 +35,23 @@ jobs:
         with:
           python-version: ${{ env.PY_VERSION }}
 
-      - name: Install tool and dependencies
+      - name: Check code formatting
+        working-directory: xl2times
+        run: |
+          python -m pip install --upgrade pre-commit
+          pre-commit install
+          pre-commit run --all-files
+
+      - name: Build and install xl2times
         working-directory: xl2times
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
-
-      # - name: Check code formatting
-      #   working-directory: xl2times
-      #   run: |
-      #     source .venv/bin/activate
-      #     pre-commit install
-      #     pre-commit run --all-files
+          python -m pip install --upgrade pip build twine
+          rm -rf dist || true
+          python -m build
+          # Install the built wheel file to imitiate users installing from PyPI:
+          python -m pip install --no-index --find-links=dist xl2times
 
       # - name: Run unit tests
       #   working-directory: xl2times
@@ -173,15 +176,7 @@ jobs:
       #     path: ~/.cache/xl2times
       #     key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
 
-      # ---------- Build package and upload to PyPI
-
-      - name: Build package
-        working-directory: xl2times
-        run: |
-          source .venv/bin/activate
-          python -m pip install --upgrade build twine
-          rm -rf dist || true
-          python -m build
+      # ---------- Upload package to PyPI on release
 
       - name: Publish to PyPI
         # if: startsWith(github.ref, 'refs/tags/v') # Only run on tags `v...`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           rm -rf dist || true
           python -m build
           # Install the built wheel file to imitiate users installing from PyPI:
-          python -m pip install --no-index --find-links=dist xl2times
+          python -m pip install --find-links=dist xl2times
 
       - name: Check code formatting
         working-directory: xl2times

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: xl2times/custom-dir/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,128 +53,128 @@ jobs:
           # Install the built wheel file to imitiate users installing from PyPI:
           python -m pip install --no-index --find-links=dist xl2times
 
-      # - name: Run unit tests
-      #   working-directory: xl2times
-      #   run: |
-      #     source .venv/bin/activate
-      #     pytest
+      - name: Run unit tests
+        working-directory: xl2times
+        run: |
+          source .venv/bin/activate
+          pytest
 
-      # # ---------- Prepare ETSAP Demo models
+      # ---------- Prepare ETSAP Demo models
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: etsap-TIMES/TIMES_model
-      #     path: TIMES_model
-      #     ref: ${{ env.REF_TIMES_model }}
+      - uses: actions/checkout@v3
+        with:
+          repository: etsap-TIMES/TIMES_model
+          path: TIMES_model
+          ref: ${{ env.REF_TIMES_model }}
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: olejandro/demos-dd
-      #     path: xl2times/benchmarks/dd
-      #     ref: ${{ env.REF_demos-dd }}
+      - uses: actions/checkout@v3
+        with:
+          repository: olejandro/demos-dd
+          path: xl2times/benchmarks/dd
+          ref: ${{ env.REF_demos-dd }}
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: olejandro/demos-xlsx
-      #     path: xl2times/benchmarks/xlsx
-      #     ref: ${{ env.REF_demos-xlsx }}
-      #     token: ${{ secrets.GH_PAT_DEMOS_XLSX }}
+      - uses: actions/checkout@v3
+        with:
+          repository: olejandro/demos-xlsx
+          path: xl2times/benchmarks/xlsx
+          ref: ${{ env.REF_demos-xlsx }}
+          token: ${{ secrets.GH_PAT_DEMOS_XLSX }}
 
-      # # ---------- Prepare TIMES Ireland Model
+      # ---------- Prepare TIMES Ireland Model
 
-      # # We add this model as the directory `ireland` under `benchmarks/{xlsx,dd}/`
-      # # so that the run_benchmarks.py script runs this model too
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: esma-cgep/tim
-      #     path: xl2times/benchmarks/xlsx/Ireland
-      #     ref: ${{ env.REF_tim }}
+      # We add this model as the directory `ireland` under `benchmarks/{xlsx,dd}/`
+      # so that the run_benchmarks.py script runs this model too
+      - uses: actions/checkout@v3
+        with:
+          repository: esma-cgep/tim
+          path: xl2times/benchmarks/xlsx/Ireland
+          ref: ${{ env.REF_tim }}
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: esma-cgep/tim-gams
-      #     path: xl2times/benchmarks/dd/Ireland
-      #     ref: ${{ env.REF_tim-gams }}
+      - uses: actions/checkout@v3
+        with:
+          repository: esma-cgep/tim-gams
+          path: xl2times/benchmarks/dd/Ireland
+          ref: ${{ env.REF_tim-gams }}
 
-      # # ---------- Install GAMS
+      # ---------- Install GAMS
 
-      # - name: Install GAMS
-      #   env:
-      #     GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
-      #   if: ${{ env.GAMS_LICENSE != '' }}
-      #   run: |
-      #     curl https://d37drm4t2jghv5.cloudfront.net/distributions/44.1.0/linux/linux_x64_64_sfx.exe -o linux_x64_64_sfx.exe
-      #     chmod +x linux_x64_64_sfx.exe
-      #     mkdir GAMS
-      #     pushd  GAMS
-      #     ../linux_x64_64_sfx.exe > /dev/null && echo Successfully installed GAMS
-      #     export PATH=$PATH:$(pwd)/gams44.1_linux_x64_64_sfx
-      #     popd
-      #     echo Creating license file at $HOME/.local/share/GAMS
-      #     mkdir -p $HOME/.local/share/GAMS
-      #     echo "$GAMS_LICENSE" > $HOME/.local/share/GAMS/gamslice.txt
-      #     ls -l $HOME/.local/share/GAMS/
+      - name: Install GAMS
+        env:
+          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+        if: ${{ env.GAMS_LICENSE != '' }}
+        run: |
+          curl https://d37drm4t2jghv5.cloudfront.net/distributions/44.1.0/linux/linux_x64_64_sfx.exe -o linux_x64_64_sfx.exe
+          chmod +x linux_x64_64_sfx.exe
+          mkdir GAMS
+          pushd  GAMS
+          ../linux_x64_64_sfx.exe > /dev/null && echo Successfully installed GAMS
+          export PATH=$PATH:$(pwd)/gams44.1_linux_x64_64_sfx
+          popd
+          echo Creating license file at $HOME/.local/share/GAMS
+          mkdir -p $HOME/.local/share/GAMS
+          echo "$GAMS_LICENSE" > $HOME/.local/share/GAMS/gamslice.txt
+          ls -l $HOME/.local/share/GAMS/
 
-      # # ---------- Run tool, check for regressions
+      # ---------- Run tool, check for regressions
 
-      # - name: Restore XLSX cache directory from cache
-      #   id: cache
-      #   uses: actions/cache/restore@v4
-      #   with:
-      #     path: ~/.cache/xl2times
-      #     # Cache key is refs of the input xlsx repos, since that's what is cached
-      #     key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
-      #     # If we can't find the exact key for the TIM repo, still use the cache if the demos repo ref matches
-      #     restore-keys: |
-      #       ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-
-      #       ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-
-      #       ${{ runner.os }}-py-${{ env.PY_VERSION }}-
+      - name: Restore XLSX cache directory from cache
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/xl2times
+          # Cache key is refs of the input xlsx repos, since that's what is cached
+          key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
+          # If we can't find the exact key for the TIM repo, still use the cache if the demos repo ref matches
+          restore-keys: |
+            ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-
+            ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-
+            ${{ runner.os }}-py-${{ env.PY_VERSION }}-
 
-      # - name: Run tool on all benchmarks
-      #   env:
-      #     GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
-      #   if: ${{ env.GAMS_LICENSE != '' }}
-      #   working-directory: xl2times
-      #   # Use tee to also save the output to out.txt so that the summary table can be
-      #   # printed again in the next step.
-      #   # Save the return code to retcode.txt so that the next step can fail the action
-      #   run: |
-      #     source .venv/bin/activate
-      #     export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
-      #     (python utils/run_benchmarks.py benchmarks.yml \
-      #         --dd --times_dir $GITHUB_WORKSPACE/TIMES_model \
-      #         --verbose \
-      #         | tee out.txt; \
-      #       echo ${PIPESTATUS[0]} > retcode.txt)
+      - name: Run tool on all benchmarks
+        env:
+          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+        if: ${{ env.GAMS_LICENSE != '' }}
+        working-directory: xl2times
+        # Use tee to also save the output to out.txt so that the summary table can be
+        # printed again in the next step.
+        # Save the return code to retcode.txt so that the next step can fail the action
+        run: |
+          source .venv/bin/activate
+          export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
+          (python utils/run_benchmarks.py benchmarks.yml \
+              --dd --times_dir $GITHUB_WORKSPACE/TIMES_model \
+              --verbose \
+              | tee out.txt; \
+            echo ${PIPESTATUS[0]} > retcode.txt)
 
-      # - name: Run CSV-only regression tests (no GAMS license)
-      #   env:
-      #     GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
-      #   if: ${{ env.GAMS_LICENSE == '' }}
-      #   working-directory: xl2times
-      #   # Run without --dd flag if GAMS license secret doesn't exist.
-      #   # Useful for testing for (CSV) regressions in forks before creating PRs.
-      #   run: |
-      #     source .venv/bin/activate
-      #     export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
-      #     (python utils/run_benchmarks.py benchmarks.yml \
-      #         --times_dir $GITHUB_WORKSPACE/TIMES_model \
-      #         --verbose \
-      #         | tee out.txt; \
-      #     echo ${PIPESTATUS[0]} > retcode.txt)
+      - name: Run CSV-only regression tests (no GAMS license)
+        env:
+          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+        if: ${{ env.GAMS_LICENSE == '' }}
+        working-directory: xl2times
+        # Run without --dd flag if GAMS license secret doesn't exist.
+        # Useful for testing for (CSV) regressions in forks before creating PRs.
+        run: |
+          source .venv/bin/activate
+          export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
+          (python utils/run_benchmarks.py benchmarks.yml \
+              --times_dir $GITHUB_WORKSPACE/TIMES_model \
+              --verbose \
+              | tee out.txt; \
+          echo ${PIPESTATUS[0]} > retcode.txt)
 
-      # - name: Print summary
-      #   working-directory: xl2times
-      #   run: |
-      #     sed -n '/Benchmark *Time.*Accuracy/h;//!H;$!d;x;//p' out.txt
-      #     exit $(cat retcode.txt)
+      - name: Print summary
+        working-directory: xl2times
+        run: |
+          sed -n '/Benchmark *Time.*Accuracy/h;//!H;$!d;x;//p' out.txt
+          exit $(cat retcode.txt)
 
-      # - uses: actions/cache/save@v4
-      #   # Save the cache even if the regression tests fail
-      #   if: always() && !steps.cache-restore.outputs.cache-hit
-      #   with:
-      #     path: ~/.cache/xl2times
-      #     key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
+      - uses: actions/cache/save@v4
+        # Save the cache even if the regression tests fail
+        if: always() && !steps.cache-restore.outputs.cache-hit
+        with:
+          path: ~/.cache/xl2times
+          key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
 
       # ---------- Upload package to PyPI on release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install --upgrade pip
+          pip install --upgrade pip build
           pip install -e .[dev]
           # Build xl2times
           rm -rf dist || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       # ---------- Upload package to PyPI on release
 
       - name: Publish to PyPI
-        if: github.event_name == 'release' && github.event.action == 'published'
+        # if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     env:
       PY_VERSION: "3.11"
@@ -181,7 +183,7 @@ jobs:
           rm -rf dist || true
           python -m build
 
-      - name: Download dist built by CI job
+      - name: Publish to PyPI
         # if: startsWith(github.ref, 'refs/tags/v') # Only run on tags `v...`
         # if: github.event_name == 'release' && github.event.action == 'created'  # TODO use this before merge
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,135 +43,135 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
 
-      - name: Check code formatting
-        working-directory: xl2times
-        run: |
-          source .venv/bin/activate
-          pre-commit install
-          pre-commit run --all-files
+      # - name: Check code formatting
+      #   working-directory: xl2times
+      #   run: |
+      #     source .venv/bin/activate
+      #     pre-commit install
+      #     pre-commit run --all-files
 
-      - name: Run unit tests
-        working-directory: xl2times
-        run: |
-          source .venv/bin/activate
-          pytest
+      # - name: Run unit tests
+      #   working-directory: xl2times
+      #   run: |
+      #     source .venv/bin/activate
+      #     pytest
 
-      # ---------- Prepare ETSAP Demo models
+      # # ---------- Prepare ETSAP Demo models
 
-      - uses: actions/checkout@v3
-        with:
-          repository: etsap-TIMES/TIMES_model
-          path: TIMES_model
-          ref: ${{ env.REF_TIMES_model }}
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: etsap-TIMES/TIMES_model
+      #     path: TIMES_model
+      #     ref: ${{ env.REF_TIMES_model }}
 
-      - uses: actions/checkout@v3
-        with:
-          repository: olejandro/demos-dd
-          path: xl2times/benchmarks/dd
-          ref: ${{ env.REF_demos-dd }}
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: olejandro/demos-dd
+      #     path: xl2times/benchmarks/dd
+      #     ref: ${{ env.REF_demos-dd }}
 
-      - uses: actions/checkout@v3
-        with:
-          repository: olejandro/demos-xlsx
-          path: xl2times/benchmarks/xlsx
-          ref: ${{ env.REF_demos-xlsx }}
-          token: ${{ secrets.GH_PAT_DEMOS_XLSX }}
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: olejandro/demos-xlsx
+      #     path: xl2times/benchmarks/xlsx
+      #     ref: ${{ env.REF_demos-xlsx }}
+      #     token: ${{ secrets.GH_PAT_DEMOS_XLSX }}
 
-      # ---------- Prepare TIMES Ireland Model
+      # # ---------- Prepare TIMES Ireland Model
 
-      # We add this model as the directory `ireland` under `benchmarks/{xlsx,dd}/`
-      # so that the run_benchmarks.py script runs this model too
-      - uses: actions/checkout@v3
-        with:
-          repository: esma-cgep/tim
-          path: xl2times/benchmarks/xlsx/Ireland
-          ref: ${{ env.REF_tim }}
+      # # We add this model as the directory `ireland` under `benchmarks/{xlsx,dd}/`
+      # # so that the run_benchmarks.py script runs this model too
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: esma-cgep/tim
+      #     path: xl2times/benchmarks/xlsx/Ireland
+      #     ref: ${{ env.REF_tim }}
 
-      - uses: actions/checkout@v3
-        with:
-          repository: esma-cgep/tim-gams
-          path: xl2times/benchmarks/dd/Ireland
-          ref: ${{ env.REF_tim-gams }}
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: esma-cgep/tim-gams
+      #     path: xl2times/benchmarks/dd/Ireland
+      #     ref: ${{ env.REF_tim-gams }}
 
-      # ---------- Install GAMS
+      # # ---------- Install GAMS
 
-      - name: Install GAMS
-        env:
-          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
-        if: ${{ env.GAMS_LICENSE != '' }}
-        run: |
-          curl https://d37drm4t2jghv5.cloudfront.net/distributions/44.1.0/linux/linux_x64_64_sfx.exe -o linux_x64_64_sfx.exe
-          chmod +x linux_x64_64_sfx.exe
-          mkdir GAMS
-          pushd  GAMS
-          ../linux_x64_64_sfx.exe > /dev/null && echo Successfully installed GAMS
-          export PATH=$PATH:$(pwd)/gams44.1_linux_x64_64_sfx
-          popd
-          echo Creating license file at $HOME/.local/share/GAMS
-          mkdir -p $HOME/.local/share/GAMS
-          echo "$GAMS_LICENSE" > $HOME/.local/share/GAMS/gamslice.txt
-          ls -l $HOME/.local/share/GAMS/
+      # - name: Install GAMS
+      #   env:
+      #     GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+      #   if: ${{ env.GAMS_LICENSE != '' }}
+      #   run: |
+      #     curl https://d37drm4t2jghv5.cloudfront.net/distributions/44.1.0/linux/linux_x64_64_sfx.exe -o linux_x64_64_sfx.exe
+      #     chmod +x linux_x64_64_sfx.exe
+      #     mkdir GAMS
+      #     pushd  GAMS
+      #     ../linux_x64_64_sfx.exe > /dev/null && echo Successfully installed GAMS
+      #     export PATH=$PATH:$(pwd)/gams44.1_linux_x64_64_sfx
+      #     popd
+      #     echo Creating license file at $HOME/.local/share/GAMS
+      #     mkdir -p $HOME/.local/share/GAMS
+      #     echo "$GAMS_LICENSE" > $HOME/.local/share/GAMS/gamslice.txt
+      #     ls -l $HOME/.local/share/GAMS/
 
-      # ---------- Run tool, check for regressions
+      # # ---------- Run tool, check for regressions
 
-      - name: Restore XLSX cache directory from cache
-        id: cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/xl2times
-          # Cache key is refs of the input xlsx repos, since that's what is cached
-          key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
-          # If we can't find the exact key for the TIM repo, still use the cache if the demos repo ref matches
-          restore-keys: |
-            ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-
-            ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-
-            ${{ runner.os }}-py-${{ env.PY_VERSION }}-
+      # - name: Restore XLSX cache directory from cache
+      #   id: cache
+      #   uses: actions/cache/restore@v4
+      #   with:
+      #     path: ~/.cache/xl2times
+      #     # Cache key is refs of the input xlsx repos, since that's what is cached
+      #     key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
+      #     # If we can't find the exact key for the TIM repo, still use the cache if the demos repo ref matches
+      #     restore-keys: |
+      #       ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-
+      #       ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-
+      #       ${{ runner.os }}-py-${{ env.PY_VERSION }}-
 
-      - name: Run tool on all benchmarks
-        env:
-          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
-        if: ${{ env.GAMS_LICENSE != '' }}
-        working-directory: xl2times
-        # Use tee to also save the output to out.txt so that the summary table can be
-        # printed again in the next step.
-        # Save the return code to retcode.txt so that the next step can fail the action
-        run: |
-          source .venv/bin/activate
-          export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
-          (python utils/run_benchmarks.py benchmarks.yml \
-              --dd --times_dir $GITHUB_WORKSPACE/TIMES_model \
-              --verbose \
-              | tee out.txt; \
-            echo ${PIPESTATUS[0]} > retcode.txt)
+      # - name: Run tool on all benchmarks
+      #   env:
+      #     GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+      #   if: ${{ env.GAMS_LICENSE != '' }}
+      #   working-directory: xl2times
+      #   # Use tee to also save the output to out.txt so that the summary table can be
+      #   # printed again in the next step.
+      #   # Save the return code to retcode.txt so that the next step can fail the action
+      #   run: |
+      #     source .venv/bin/activate
+      #     export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
+      #     (python utils/run_benchmarks.py benchmarks.yml \
+      #         --dd --times_dir $GITHUB_WORKSPACE/TIMES_model \
+      #         --verbose \
+      #         | tee out.txt; \
+      #       echo ${PIPESTATUS[0]} > retcode.txt)
 
-      - name: Run CSV-only regression tests (no GAMS license)
-        env:
-          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
-        if: ${{ env.GAMS_LICENSE == '' }}
-        working-directory: xl2times
-        # Run without --dd flag if GAMS license secret doesn't exist.
-        # Useful for testing for (CSV) regressions in forks before creating PRs.
-        run: |
-          source .venv/bin/activate
-          export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
-          (python utils/run_benchmarks.py benchmarks.yml \
-              --times_dir $GITHUB_WORKSPACE/TIMES_model \
-              --verbose \
-              | tee out.txt; \
-          echo ${PIPESTATUS[0]} > retcode.txt)
+      # - name: Run CSV-only regression tests (no GAMS license)
+      #   env:
+      #     GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+      #   if: ${{ env.GAMS_LICENSE == '' }}
+      #   working-directory: xl2times
+      #   # Run without --dd flag if GAMS license secret doesn't exist.
+      #   # Useful for testing for (CSV) regressions in forks before creating PRs.
+      #   run: |
+      #     source .venv/bin/activate
+      #     export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
+      #     (python utils/run_benchmarks.py benchmarks.yml \
+      #         --times_dir $GITHUB_WORKSPACE/TIMES_model \
+      #         --verbose \
+      #         | tee out.txt; \
+      #     echo ${PIPESTATUS[0]} > retcode.txt)
 
-      - name: Print summary
-        working-directory: xl2times
-        run: |
-          sed -n '/Benchmark *Time.*Accuracy/h;//!H;$!d;x;//p' out.txt
-          exit $(cat retcode.txt)
+      # - name: Print summary
+      #   working-directory: xl2times
+      #   run: |
+      #     sed -n '/Benchmark *Time.*Accuracy/h;//!H;$!d;x;//p' out.txt
+      #     exit $(cat retcode.txt)
 
-      - uses: actions/cache/save@v4
-        # Save the cache even if the regression tests fail
-        if: always() && !steps.cache-restore.outputs.cache-hit
-        with:
-          path: ~/.cache/xl2times
-          key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
+      # - uses: actions/cache/save@v4
+      #   # Save the cache even if the regression tests fail
+      #   if: always() && !steps.cache-restore.outputs.cache-hit
+      #   with:
+      #     path: ~/.cache/xl2times
+      #     key: ${{ runner.os }}-py-${{ env.PY_VERSION }}-${{ env.REF_demos-xlsx }}-${{ env.REF_tim }}-${{ env.CACHE_KEY }}
 
       # ---------- Build package and upload to PyPI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       # ---------- Upload package to PyPI on release
 
       - name: Publish to PyPI
-        # if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -179,8 +181,7 @@ jobs:
       # ---------- Upload package to PyPI on release
 
       - name: Publish to PyPI
-        # if: startsWith(github.ref, 'refs/tags/v') # Only run on tags `v...`
-        # if: github.event_name == 'release' && github.event.action == 'created'  # TODO use this before merge
+        if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,20 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          python -m pip install --upgrade pip build
+          pip install --upgrade pip
+          pip install -e .[dev]
+          # Build xl2times
           rm -rf dist || true
           python -m build
           # Install the built wheel file to imitiate users installing from PyPI:
-          python -m pip install --find-links=dist xl2times
+          pip uninstall --yes xl2times
+          pip install --find-links=dist xl2times
 
       - name: Check code formatting
         working-directory: xl2times
         # Run this step after install so that pyright can find dependencies like pandas
         run: |
           source .venv/bin/activate
-          python -m pip install --upgrade pre-commit
           pre-commit install
           pre-commit run --all-files
 
@@ -61,7 +63,6 @@ jobs:
         working-directory: xl2times
         run: |
           source .venv/bin/activate
-          python -m pip install --upgrade pytest
           pytest
 
       # ---------- Prepare ETSAP Demo models

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,4 +189,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: xl2times/custom-dir/
+          packages-dir: xl2times/dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         working-directory: xl2times
         run: |
           source .venv/bin/activate
+          python -m pip install --upgrade pytest
           pytest
 
       # ---------- Prepare ETSAP Demo models

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,14 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-added-large-files
+        args: ["--maxkb=2000"]
 
   - repo: https://github.com/psf/black
     rev: 22.8.0

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ We recommend installing the tool in editable mode (`-e`) in a Python virtual env
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -U pip
-pip install -r requirements.txt
 pip install -e .[dev]
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,14 +132,11 @@ VS Code will highlight the changes in the two files, which should correspond to 
 
 ### Publishing the Tool
 
-To publish a new version of the tool on PyPI, update the version number in `pyproject.toml`, and then run:
-```bash
-python -m pip install --upgrade build
-python -m pip install --upgrade twine
-rm -rf dist
-python -m build
-python -m twine upload dist/*
-```
+Follow these steps to release a new version of `xl2times` and publish it on PyPI:
+- [ ] Bump the version number in `pyproject.toml` (use [Semantic Versioning](https://semver.org/))
+- [ ] Open a PR with this change titled "Release vX.Y.Z"
+- [ ] When the PR is merged, create a [new release](https://github.com/etsap-TIMES/xl2times/releases/new) titled "vX.Y.Z". Select "Create a new tag: on publish" and click "Generate release notes" to generate the notes automatically.
+- [ ] Click "Publish release" to publish the release on GitHub. A GitHub Actions workflow will automatically upload the distribution to PyPI.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ VS Code will highlight the changes in the two files, which should correspond to 
 ### Publishing the Tool
 
 Follow these steps to release a new version of `xl2times` and publish it on PyPI:
-- [ ] Bump the version number in `pyproject.toml` (use [Semantic Versioning](https://semver.org/))
+- [ ] Bump the version number in `pyproject.toml` and `xl2times/__init__.py` (use [Semantic Versioning](https://semver.org/))
 - [ ] Open a PR with this change titled "Release vX.Y.Z"
 - [ ] When the PR is merged, create a [new release](https://github.com/etsap-TIMES/xl2times/releases/new) titled "vX.Y.Z". Select "Create a new tag: on publish" and click "Generate release notes" to generate the notes automatically.
 - [ ] Click "Publish release" to publish the release on GitHub. A GitHub Actions workflow will automatically upload the distribution to PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["xl2times", "xl2times.*"]
 
 [project]
 name = "xl2times"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = [
     { name="Sam Webster", email="13457618+samwebster@users.noreply.github.com" },
     { name="Tom Minka", email="8955276+tminka@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["xl2times"]
 
 [project]
 name = "xl2times"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.1"
 authors = [
     { name="Sam Webster", email="13457618+samwebster@users.noreply.github.com" },
     { name="Tom Minka", email="8955276+tminka@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["xl2times"]
+[tool.setuptools.packages.find]
+where = [""]
+include = ["xl2times", "xl2times.*"]
 
 [project]
 name = "xl2times"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["xl2times"]
 
 [project]
 name = "xl2times"
-version = "0.1.0"
+version = "0.1.0-alpha"
 authors = [
     { name="Sam Webster", email="13457618+samwebster@users.noreply.github.com" },
     { name="Tom Minka", email="8955276+tminka@users.noreply.github.com" },


### PR DESCRIPTION
- Build the distribution package (wheel file) in CI
- Install from wheel file so that CI tests imitate users who install xl2times from PyPI
- CD: when releases are published on GitHub, automatically upload to PyPI
- Add release instruction to README

I'm merging this PR in so that I can test the publish-upon-release action with Test-PyPI. If you have any comments, please leave them here, and I'll resolve them in the next PR that swaps Test-PyPI for real PyPI. Thanks!