### PR TITLE
Set output float precision & relative epsilon for DD comparison

### DIFF
--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -117,6 +117,7 @@ def run_gams_gdxdiff(
             path.join(out_folder, "scenario.gdx"),
             path.join(out_folder, "diffile.gdx"),
             "Eps=0.000001",
+            "RelEps=0.000001",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -128,7 +128,21 @@ def run_gams_gdxdiff(
         logger.info(res.stdout)
         logger.info(res.stderr if res.stderr is not None else "")
     if res.returncode != 0:
-        return f"Diff ({len(res.stdout.splitlines())})"
+        # Report the number of lines in the gdxdump of the difffile
+        res = subprocess.run(
+            ["gdxdump", path.join(out_folder, "diffile.gdx")],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+        if verbose or res.returncode != 0:
+            logger.info(res.stdout)
+            logger.info(res.stderr if res.stderr is not None else "")
+        if res.returncode != 0:
+            logger.error(f"GAMS gdxdiff failed on {benchmark['name']}")
+            sys.exit(4)
+        return str(len(res.stdout.splitlines()))
 
     return "OK"
 

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -206,7 +206,7 @@ def read_csv_tables(input_dir: str) -> dict[str, DataFrame]:
     result = {}
     csv_files = list(Path(input_dir).glob("*.csv"))
     for filename in csv_files:
-        result[filename.stem] = pd.read_csv(filename, dtype=str)
+        result[filename.stem] = pd.read_csv(filename)
     return result
 
 
@@ -508,6 +508,8 @@ def run(args: argparse.Namespace) -> str | None:
 
     if args.ground_truth_dir:
         ground_truth = read_csv_tables(args.ground_truth_dir)
+        # Use the same convert_to_string transform on GT so that comparisons are fair
+        ground_truth = transforms.convert_to_string(config, ground_truth, model)
         comparison = compare(tables, ground_truth, args.output_dir)
         return comparison
     else:

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2733,7 +2733,9 @@ def convert_to_string(
 ) -> dict[str, DataFrame]:
     for key, value in tables.items():
         tables[key] = value.map(
-            lambda x: str(int(x)) if isinstance(x, float) and x.is_integer() else str(x)
+            lambda x: (str(int(x)) if x.is_integer() else f"{x:.10g}")
+            if isinstance(x, float)
+            else str(x)
         )
     return tables
 


### PR DESCRIPTION
An attempted fix for #246, which was first noticed in #240. With some [trial and error](https://github.com/etsap-TIMES/xl2times/pull/240#issuecomment-2507218132) I set a precision of `.10g` (10 significant figures in exponential/scientific notation) for floating point numbers.

I also had to change the `gdxdiff` options to additionally use a tolerance in relative difference when comparing the output DD files to the ground truth, otherwise the higher precision output above increased the DD diff. We now use `1e-6` for both absolute `Eps` and relative `RelEps` difference tolerance. If I understand correctly how `gdxdiff` [works](https://www.gams.com/latest/docs/T_GDXDIFF.html#GDXDIFF_OPTIONS_CRITERIONEXPLANATION), this feels like a reasonable tolerance:
```
AbsDiff := Abs(V1 - V2);
if  AbsDiff <= EpsAbsolute
then
  Result := true
else
  if EpsRelative > 0.0
  then
     Result := AbsDiff / (1.0 + DMin(Abs(V1), Abs(V2))) <= EpsRelative
  else
     Result := false;
```

Finally, we were reporting the number of lines in the output of `gdxdiff`, but that's only the number of sets/parameters that are different, and doesn't track improvements in number of rows different. I'm now passing the output of `gdxdiff` to `gdxdump` so that the "GDX Diff" column is more accurate and tracks number of rows in the diff.