### PR TITLE
Update version of TIMES-NZ in benchmarks

### DIFF
--- a/setup-benchmarks.sh
+++ b/setup-benchmarks.sh
@@ -10,7 +10,7 @@ REF_demos_xlsx="34a2a5c044cc0bbea1357de50db2f5f02d575181"
 REF_demos_dd="2848a8a8e2fdcf0cdf7f83eefbdd563b0bb74e86"
 REF_tim="e820d8002adc6b1526a3bffcc439219b28d0eed5"
 REF_tim_gams="703f6a4e1d0bedd95c3ebdae534496f3a7e1b7cc"
-REF_TIMES_NZ="d6d7b14f43a89ceca7c4e77ba9122a2c757cdae3"
+REF_TIMES_NZ="4170d720e1c5cb0e31537a3168188169209ceb4d"
 
 # If no GitHub token is provided, try to clone using SSH
 if [ -z "$GH_PAT_DEMOS_XLSX" ]; then


### PR DESCRIPTION
The process tag in TIMES-NZ was misaligned affecting #253 