### PR TITLE
Refine application of trans files

### DIFF
--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -136,12 +136,12 @@ def convert_xl_to_times(
         transforms.generate_uc_properties,
         transforms.expand_rows_parallel,  # slow
         transforms.remove_invalid_values,
+        transforms.include_tables_source,
         transforms.internalise_commodities,
         transforms.generate_commodity_groups,
         transforms.apply_fixups,
         transforms.fill_in_missing_pcgs,
         transforms.generate_trade,
-        transforms.include_tables_source,
         transforms.merge_tables,
         transforms.complete_processes,
         transforms.process_units,

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2740,11 +2740,11 @@ def apply_transform_tables(
                         drop = ~module_data[obj].isin(valid_objs) & module_data[
                             "attribute"
                         ].isin(attr_with_obj[obj])
-                        if any(drop):
-                            module_data = module_data[~drop]
-            tables[Tag.fi_t] = pd.concat(
-                [tables[Tag.fi_t], module_data], ignore_index=True
-            )
+                        module_data = module_data[~drop]
+            if not module_data.empty:
+                tables[Tag.fi_t] = pd.concat(
+                    [tables[Tag.fi_t], module_data], ignore_index=True
+                )
 
     return tables
 


### PR DESCRIPTION
Refine application of the tfm tables in trans files by removing any row in generated tables that:
- for an attribute with process in indices, includes a process that is not declared in the corresponding non-trans file;
- for an attribute with commodity in indices, includes a commodity that is not declared in the corresponding non-trans file, base or syssettings.

This PR should enable #256 