### PR TITLE
Improve querying

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,15 +1,12 @@
-from datetime import datetime
-
 import pandas as pd
 from pandas import DataFrame
 
-from xl2times import datatypes, transforms, utils
+from xl2times import transforms, utils
 from xl2times.transforms import (
     _count_comm_group_vectorised,
     _match_wildcards,
     _process_comm_groups_vectorised,
     commodity_map,
-    expand_rows,
     get_matching_commodities,
     get_matching_processes,
     process_map,
@@ -17,58 +14,11 @@ from xl2times.transforms import (
 
 logger = utils.get_logger()
 
-pd.set_option(
-    "display.max_rows",
-    20,
-    "display.max_columns",
-    20,
-    "display.width",
-    300,
-    "display.max_colwidth",
-    75,
-    "display.precision",
-    3,
-)
-
-
-def _match_uc_wildcards_old(
-    df: pd.DataFrame, dictionary: dict[str, pd.DataFrame]
-) -> pd.DataFrame:
-    """Old version of the process_uc_wildcards matching logic, for comparison with the
-    new vectorised version.
-
-    TODO remove this function once validated.
-    """
-
-    def make_str(df):
-        if df is not None and len(df) != 0:
-            list_from_df = df.iloc[:, 0].unique()
-            return ",".join(list_from_df)
-        else:
-            return None
-
-    df["process"] = df.apply(
-        lambda row: make_str(get_matching_processes(row, dictionary)), axis=1
-    )
-    df["commodity"] = df.apply(
-        lambda row: make_str(get_matching_commodities(row, dictionary)), axis=1
-    )
-
-    query_columns = transforms.process_map.keys() | transforms.commodity_map.keys()
-    cols_to_drop = [col for col in df.columns if col in query_columns]
-
-    df = expand_rows(
-        query_columns,
-        datatypes.EmbeddedXlTable(
-            tag="",
-            uc_sets={},
-            sheetname="",
-            range="",
-            filename="",
-            dataframe=df.drop(columns=cols_to_drop),
-        ),
-    ).dataframe
-    return df
+pd.set_option("display.max_rows", 20)
+pd.set_option("display.max_columns", 20)
+pd.set_option("display.width", 300)
+pd.set_option("display.max_colwidth", 75)
+pd.set_option("display.precision", 3)
 
 
 class TestTransforms:
@@ -91,12 +41,7 @@ class TestTransforms:
         assert df2["name"].equals(correct)
 
     def test_uc_wildcards(self):
-        """Tests logic that matches wildcards in the process_uc_wildcards transform .
-
-        Results on Ireland model:
-            Old method took 0:00:08.42 seconds
-            New method took 0:00:00.18 seconds, speedup: 46.5x
-        """
+        """Tests logic that matches wildcards in the process_uc_wildcards transform."""
         import pickle
 
         df_in = pd.read_parquet("tests/data/process_uc_wildcards_ireland_data.parquet")
@@ -104,41 +49,23 @@ class TestTransforms:
             dictionary = pickle.load(f)
         df = df_in.copy()
 
-        t0 = datetime.now()
-
-        # optimised functions
-        df_new = _match_wildcards(
+        df = _match_wildcards(
             df, process_map, dictionary, get_matching_processes, "process"
         )
-        df_new = _match_wildcards(
-            df_new, commodity_map, dictionary, get_matching_commodities, "commodity"
-        )
-
-        t1 = datetime.now()
-
-        # Unoptimised function
-        df_old = _match_uc_wildcards_old(df, dictionary)
-
-        t2 = datetime.now()
-
-        logger.info(f"Old method took {t2 - t1} seconds")
-        logger.info(
-            f"New method took {t1 - t0} seconds, speedup: {((t2 - t1) / (t1 - t0)):.1f}x"
+        df = _match_wildcards(
+            df, commodity_map, dictionary, get_matching_commodities, "commodity"
         )
 
         # unit tests
-        assert df_new is not None and not df_new.empty
+        assert df is not None and not df.empty
         assert (
-            df_new.shape[0] >= df_in.shape[0]
+            df.shape[0] >= df_in.shape[0]
         ), "should have more rows after processing uc_wildcards"
         assert (
-            df_new.shape[1] < df_in.shape[1]
+            df.shape[1] < df_in.shape[1]
         ), "should have fewer columns after processing uc_wildcards"
-        assert "process" in df_new.columns, "should have added process column"
-        assert "commodity" in df_new.columns, "should have added commodity column"
-
-        # consistency checks with old method
-        assert len(set(df_new.columns).symmetric_difference(set(df_old.columns))) == 0
+        assert "process" in df.columns, "should have added process column"
+        assert "commodity" in df.columns, "should have added commodity column"
 
     def test_generate_commodity_groups(self):
         """Tests that the _count_comm_group_vectorised function works as expected.

--- a/xl2times/config/veda-tags.json
+++ b/xl2times/config/veda-tags.json
@@ -256,7 +256,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "sets",
@@ -272,7 +273,8 @@
         "inherit_above": true,
         "remove_first_row_if_absent": false,
         "remove_any_row_if_absent": false,
-        "default_to": "PRE"
+        "default_to": "PRE",
+        "comma-separated-list": true
       },
       {
         "name": "tact",
@@ -401,7 +403,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "commodity-in",
@@ -419,7 +422,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "commodity-in-aux",
@@ -438,7 +442,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "commodity-out",
@@ -456,7 +461,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "commodity-out-aux",
@@ -475,7 +481,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "currency",
@@ -524,7 +531,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "process",
@@ -553,7 +561,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "sow",
@@ -644,10 +653,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -659,10 +669,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -674,10 +685,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -692,10 +704,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -707,10 +720,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       }
     ]
   },
@@ -733,7 +747,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -751,7 +766,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -766,7 +782,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "description",
@@ -1855,7 +1872,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -1873,7 +1891,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -1888,7 +1907,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "curr",
@@ -1919,7 +1939,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "other_indexes",
@@ -1934,7 +1955,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_ci",
@@ -1949,7 +1971,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -1964,7 +1987,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -1979,7 +2003,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -1997,7 +2022,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -2012,7 +2038,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "region",
@@ -2025,7 +2052,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "side",
@@ -2203,7 +2231,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       }
     ]
   },
@@ -2275,7 +2304,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -2293,7 +2323,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -2308,7 +2339,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_ci",
@@ -2323,7 +2355,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -2338,7 +2371,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -2353,7 +2387,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -2371,7 +2406,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -2386,7 +2422,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "region",
@@ -2399,7 +2436,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "value",
@@ -2415,7 +2453,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       }
     ]
   },
@@ -2585,7 +2624,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -2603,7 +2643,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -2618,7 +2659,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "curr",
@@ -2661,10 +2703,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "limtype2",
@@ -2693,10 +2736,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "other_indexes2",
@@ -2712,7 +2756,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_ci",
@@ -2727,7 +2772,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -2742,7 +2788,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -2757,7 +2804,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -2775,7 +2823,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -2790,7 +2839,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "region",
@@ -2800,10 +2850,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "side",
@@ -2825,7 +2876,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "sow",
@@ -2930,7 +2982,7 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
         "remove_any_row_if_absent": false
@@ -3019,10 +3071,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "year2",
@@ -3345,10 +3398,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -3363,10 +3417,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -3378,10 +3433,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_ci",
@@ -3393,10 +3449,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -3408,10 +3465,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -3423,10 +3481,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -3441,10 +3500,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -3456,10 +3516,11 @@
         "row_ignore_symbol": [
           "\\I:"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "region",
@@ -3471,7 +3532,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "t_neg_andor",
@@ -3666,7 +3728,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -3684,7 +3747,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -3699,7 +3763,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "curr",
@@ -3727,10 +3792,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "other_indexes",
@@ -3743,10 +3809,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_ci",
@@ -3761,7 +3828,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -3776,7 +3844,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -3791,7 +3860,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -3809,7 +3879,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -3824,7 +3895,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "region",
@@ -3834,10 +3906,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "side",
@@ -3859,7 +3932,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "sow",
@@ -3938,10 +4012,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "top_check",
@@ -3965,7 +4040,7 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
         "remove_any_row_if_absent": false
@@ -4011,10 +4086,11 @@
           "\\I:",
           "*"
         ],
-        "query_field": false,
+        "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       }
     ]
   },
@@ -4281,7 +4357,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_cn",
@@ -4299,7 +4376,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "cset_set",
@@ -4314,7 +4392,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "currency",
@@ -4376,7 +4455,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_co",
@@ -4391,7 +4471,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pd",
@@ -4406,7 +4487,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_pn",
@@ -4424,7 +4506,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "pset_set",
@@ -4439,7 +4522,8 @@
         "query_field": true,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "region",
@@ -4451,7 +4535,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "side",
@@ -4648,7 +4733,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       }
     ]
   },

--- a/xl2times/config/veda-tags.json
+++ b/xl2times/config/veda-tags.json
@@ -607,7 +607,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "year",
@@ -2146,7 +2147,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "top_check",
@@ -4629,7 +4631,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "top_check",

--- a/xl2times/config/veda-tags.json
+++ b/xl2times/config/veda-tags.json
@@ -204,7 +204,8 @@
         "query_field": false,
         "inherit_above": false,
         "remove_first_row_if_absent": false,
-        "remove_any_row_if_absent": false
+        "remove_any_row_if_absent": false,
+        "comma-separated-list": true
       },
       {
         "name": "unit",

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -68,7 +68,7 @@ class Tag(str, Enum):
     unitconversion = "~UNITCONVERSION"
 
     @classmethod
-    def has_tag(cls, tag):
+    def has_tag(cls, tag: "Tag") -> bool:
         return tag in cls._value2member_map_
 
 

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -306,6 +306,8 @@ class Config:
     known_columns: dict[Tag, set[str]]
     # Query columns for each tag
     query_columns: dict[Tag, set[str]]
+    # Columns that may contain lists for each tag
+    lists_columns: dict[Tag, set[str]]
     # Required columns for each tag
     required_columns: dict[Tag, set[str]]
     # Names of regions to include in the model; if empty, all regions are included.
@@ -336,6 +338,7 @@ class Config:
             self.row_comment_chars,
             self.discard_if_empty,
             self.query_columns,
+            self.lists_columns,
             self.known_columns,
             self.required_columns,
             self.forward_fill_cols,
@@ -507,6 +510,7 @@ class Config:
         dict[Tag, set[str]],
         dict[Tag, set[str]],
         dict[Tag, set[str]],
+        dict[Tag, set[str]],
     ]:
         def to_tag(s: str) -> Tag:
             # The file stores the tag name in lowercase, and without the ~
@@ -529,6 +533,7 @@ class Config:
         row_comment_chars = {}
         discard_if_empty = []
         query_cols = defaultdict(set)
+        lists_cols = defaultdict(set)
         known_cols = defaultdict(set)
         required_cols = defaultdict(set)
         forward_fill_cols = defaultdict(set)
@@ -560,6 +565,12 @@ class Config:
                     if valid_field["query_field"]:
                         query_cols[tag_name].add(field_name)
 
+                    if (
+                        "comma-separated-list" in valid_field
+                        and valid_field["comma-separated-list"]
+                    ):
+                        lists_cols[tag_name].add(field_name)
+
                     if valid_field["remove_any_row_if_absent"]:
                         required_cols[tag_name].add(field_name)
 
@@ -587,6 +598,8 @@ class Config:
                     row_comment_chars[tag_name] = row_comment_chars[base_tag]
                 if base_tag in query_cols:
                     query_cols[tag_name] = query_cols[base_tag]
+                if base_tag in lists_cols:
+                    lists_cols[tag_name] = lists_cols[base_tag]
                 if base_tag in known_cols:
                     known_cols[tag_name] = known_cols[base_tag]
                 if base_tag in forward_fill_cols:
@@ -598,6 +611,7 @@ class Config:
             row_comment_chars,
             discard_if_empty,
             query_cols,
+            lists_cols,
             known_cols,
             required_cols,
             forward_fill_cols,

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -69,7 +69,7 @@ class Tag(str, Enum):
     unitconversion = "~UNITCONVERSION"
 
     @classmethod
-    def has_tag(cls, tag: "Tag") -> bool:
+    def has_tag(cls, tag: str) -> bool:
         return tag in cls._value2member_map_
 
 

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -38,6 +38,7 @@ class Tag(str, Enum):
     milestoneyears = "~MILESTONEYEARS"
     start_year = "~STARTYEAR"
     tfm_ava = "~TFM_AVA"
+    tfm_ava_c = "~TFM_AVA-C"
     tfm_comgrp = "~TFM_COMGRP"
     tfm_csets = "~TFM_CSETS"
     tfm_dins = "~TFM_DINS"

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -93,7 +93,7 @@ def _remove_df_comment_rows(
     comment_rows = set()
 
     for colname in df.columns:
-        if colname in comment_chars.keys():
+        if colname in comment_chars:
             comment_rows.update(
                 list(
                     locate(
@@ -850,8 +850,8 @@ def fill_in_missing_values(
     tables: list[EmbeddedXlTable],
     model: TimesModel,
 ) -> list[EmbeddedXlTable]:
-    """Attempt to fill in missing values for all tables except update tables (as these
-    contain wildcards). How the value is filled in depends on the name of the column the
+    """Attempt to fill in missing values for all tables except upd and mig tables (as these
+    query data). How the value is filled in depends on the name of the column the
     empty values belong to.
 
     Parameters
@@ -959,14 +959,18 @@ def fill_in_missing_values(
     return result
 
 
-def expand_rows(query_columns: set[str], table: EmbeddedXlTable) -> EmbeddedXlTable:
-    """Expand entries with commas into separate entries in the same column. Do this for
-    all tables except transformation update tables.
+def expand_rows(
+    query_columns: set[str], lists_columns: set[str], table: EmbeddedXlTable
+) -> EmbeddedXlTable:
+    """Expand entries with commas in lists_columns into separate entries in the same column. Do this for
+    all tables; keep entries in query_columns as lists.
 
     Parameters
     ----------
     query_columns
         List of query column names.
+    lists_columns
+        List of columns that may contain comma-separated lists.
     table
         Table in EmbeddedXlTable format.
 
@@ -976,7 +980,7 @@ def expand_rows(query_columns: set[str], table: EmbeddedXlTable) -> EmbeddedXlTa
         Table in EmbeddedXlTable format with expanded comma entries.
     """
 
-    def has_comma(s):
+    def has_comma(s) -> bool:
         return isinstance(s, str) and "," in s
 
     def split_by_commas(s):
@@ -985,19 +989,27 @@ def expand_rows(query_columns: set[str], table: EmbeddedXlTable) -> EmbeddedXlTa
         else:
             return s
 
+    # Exclude columns that have patterns
+    exclude_cols = set(process_map.keys()).union(set(commodity_map.keys()))
+    lists_columns = lists_columns - exclude_cols
     df = table.dataframe.copy()
     c = df.map(has_comma)
-    columns_with_commas = [
+    cols_to_make_lists = [
         colname
         for colname in c.columns
-        if colname not in query_columns and c[colname].any()
+        if colname in lists_columns and c[colname].any()
     ]
-    if len(columns_with_commas) > 0:
+    cols_to_explode = [
+        colname for colname in cols_to_make_lists if colname not in query_columns
+    ]
+
+    if len(cols_to_make_lists) > 0:
         # Transform comma-separated strings into lists
-        df[columns_with_commas] = df[columns_with_commas].map(split_by_commas)
-        for colname in columns_with_commas:
-            # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.explode.html#pandas.DataFrame.explode
-            df = df.explode(colname, ignore_index=True)
+        df[cols_to_make_lists] = df[cols_to_make_lists].map(split_by_commas)
+        if len(cols_to_explode) > 0:
+            for colname in cols_to_explode:
+                # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.explode.html#pandas.DataFrame.explode
+                df = df.explode(colname, ignore_index=True)
     return replace(table, dataframe=df)
 
 
@@ -2387,44 +2399,37 @@ def query(
     process: str | list | None,
     commodity: str | list | None,
     attribute: str | None,
-    region: str | None,
-    year: int | None,
-    limtype: str | None,
+    region: str | list | None,
+    year: int | list | None,
+    limtype: str | list | None,
     val: int | float | None,
-    module: str | None,
+    module: str | list | None,
 ) -> pd.Index:
+
+    query_fields = {
+        "process": process,
+        "commodity": commodity,
+        "attribute": attribute,
+        "region": region,
+        "year": year,
+        "limtype": limtype,
+        "value": val,
+        "module_name": module,
+    }
+
+    def is_missing(field):
+        return (
+            field in [None, ""] or pd.isna(field)
+            if not isinstance(field, list)
+            else pd.isna(field).all()
+        )
+
     qs = []
 
-    # special handling for commodity and process, which can be lists or arbitrary scalars
-    missing_commodity = (
-        commodity is None or pd.isna(commodity)
-        if not isinstance(commodity, list)
-        else pd.isna(commodity).all()
-    )
-    missing_process = (
-        process is None or pd.isna(process)
-        if not isinstance(process, list)
-        else pd.isna(process).all()
-    )
+    for k, v in query_fields.items():
+        if not is_missing(v):
+            qs.append(f"{k} in {v if isinstance(v, list) else [v]}")
 
-    if not missing_process:
-        qs.append(f"process in {process if isinstance(process, list) else [process]}")
-    if not missing_commodity:
-        qs.append(
-            f"commodity in {commodity if isinstance(commodity, list) else [commodity]}"
-        )
-    if attribute is not None:
-        qs.append(f"attribute == '{attribute}'")
-    if region is not None:
-        qs.append(f"region == '{region}'")
-    if year not in [None, ""]:
-        qs.append(f"year == {year}")
-    if limtype not in [None, ""]:
-        qs.append(f"limtype == '{limtype}'")
-    if val not in [None, ""]:
-        qs.append(f"value == {val}")
-    if module not in [None, ""]:
-        qs.append(f"module_name == '{module}'")
     query_str = " and ".join(qs)
     row_idx = table.query(query_str).index
     return row_idx
@@ -3285,5 +3290,11 @@ def expand_rows_parallel(
         (config.query_columns[Tag(table.tag)] if Tag.has_tag(table.tag) else set())
         for table in tables
     ]
+    lists_columns_lists = [
+        (config.lists_columns[Tag(table.tag)] if Tag.has_tag(table.tag) else set())
+        for table in tables
+    ]
     with ProcessPoolExecutor(max_workers) as executor:
-        return list(executor.map(expand_rows, query_columns_lists, tables))
+        return list(
+            executor.map(expand_rows, query_columns_lists, lists_columns_lists, tables)
+        )

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1048,11 +1048,7 @@ def remove_invalid_values(
     # TODO: FI_T and UC_T should take into account whether a specific dimension is required
     skip_tags = {
         Tag.tfm_ava,
-        Tag.tfm_comgrp,
-        Tag.tfm_ins,
-        Tag.tfm_ins_txt,
         Tag.tfm_mig,
-        Tag.tfm_topins,
         Tag.tfm_upd,
         Tag.uc_t,
     }

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1374,12 +1374,12 @@ def generate_commodity_groups(
             subset=["region", "process", "io", "commodity", "csets", "commoditygroup"],
             keep="first",
             inplace=True,
+            ignore_index=True,
         )
 
     # TODO: Include info from ~TFM_TOPINS e.g. include RSDAHT2 in addition to RSDAHT
 
     model.topology = comm_groups
-    print(model.topology)
 
     return tables
 
@@ -1813,7 +1813,6 @@ def process_topology(
         for col in cols_with_comma:
             topology = topology.explode(col, ignore_index=True)
     model.topology = topology
-    print(model.topology)
 
     return tables
 
@@ -2521,7 +2520,6 @@ def apply_transform_tables(
             on=["region", "process"],
             how="inner",
         )
-        print(model.topology)
 
     # Create a dictionary of processes/commodities indexed by module name
     obj_by_module = dict()
@@ -3052,7 +3050,6 @@ def fix_topology(
     mapping = {"IN-A": "IN", "OUT-A": "OUT"}
 
     model.topology.replace({"io": mapping}, inplace=True)
-    print(model.topology)
 
     return tables
 


### PR DESCRIPTION
This PR allows other fields (in addition to `process` and `commodity`) to be passed as lists to `query`. It also allows column-wise control of which dataframe entries should be exploded if a comma is found.