### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           python -m build
           # Install the built wheel file to imitiate users installing from PyPI:
           pip uninstall --yes xl2times
-          pip install --find-links=dist xl2times
+          pip install --no-index --find-links=dist xl2times
 
       - name: Check code formatting
         working-directory: xl2times

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,8 +7,6 @@ from xl2times.transforms import (
     _match_wildcards,
     _process_comm_groups_vectorised,
     commodity_map,
-    get_matching_commodities,
-    get_matching_processes,
     process_map,
 )
 
@@ -49,12 +47,8 @@ class TestTransforms:
             dictionary = pickle.load(f)
         df = df_in.copy()
 
-        df = _match_wildcards(
-            df, process_map, dictionary, get_matching_processes, "process"
-        )
-        df = _match_wildcards(
-            df, commodity_map, dictionary, get_matching_commodities, "commodity"
-        )
+        df = _match_wildcards(df, process_map, dictionary, "process")
+        df = _match_wildcards(df, commodity_map, dictionary, "commodity")
 
         # unit tests
         assert df is not None and not df.empty

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -47,8 +47,11 @@ class TestTransforms:
             dictionary = pickle.load(f)
         df = df_in.copy()
 
-        df = _match_wildcards(df, process_map, dictionary, "process", explode=False)
-        df = _match_wildcards(df, commodity_map, dictionary, "commodity", explode=False)
+        for result_col, item_map in {
+            "process": process_map,
+            "commodity": commodity_map,
+        }.items():
+            df = _match_wildcards(df, item_map, dictionary, result_col)
 
         # unit tests
         assert df is not None and not df.empty

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -47,8 +47,8 @@ class TestTransforms:
             dictionary = pickle.load(f)
         df = df_in.copy()
 
-        df = _match_wildcards(df, process_map, dictionary, "process")
-        df = _match_wildcards(df, commodity_map, dictionary, "commodity")
+        df = _match_wildcards(df, process_map, dictionary, "process", explode=False)
+        df = _match_wildcards(df, commodity_map, dictionary, "commodity", explode=False)
 
         # unit tests
         assert df is not None and not df.empty

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -220,14 +220,14 @@ def compare(
         f" {sum(df.shape[0] for _, df in ground_truth.items())} rows"
     )
 
-    missing = set(ground_truth.keys()) - set(data.keys())
+    missing = set(ground_truth.keys()).difference(data.keys())
     missing_str = ", ".join(
         [f"{x} ({ground_truth[x].shape[0]})" for x in sorted(missing)]
     )
     if len(missing) > 0:
         logger.warning(f"Missing {len(missing)} tables: {missing_str}")
 
-    additional_tables = set(data.keys()) - set(ground_truth.keys())
+    additional_tables = set(data.keys()).difference(ground_truth.keys())
     additional_str = ", ".join(
         [f"{x} ({data[x].shape[0]})" for x in sorted(additional_tables)]
     )
@@ -258,9 +258,9 @@ def compare(
             data_rows = set(str(row).lower() for row in data_table.to_numpy().tolist())
             total_gt_rows += len(gt_rows)
             total_correct_rows += len(gt_rows.intersection(data_rows))
-            additional = data_rows - gt_rows
+            additional = data_rows.difference(gt_rows)
             total_additional_rows += len(additional)
-            missing = gt_rows - data_rows
+            missing = gt_rows.difference(data_rows)
             if len(additional) != 0 or len(missing) != 0:
                 logger.warning(
                     f"Table {table_name} ({data_table.shape[0]} rows,"
@@ -320,7 +320,7 @@ def produce_times_tables(
             if "techgroup" in mapping.xl_cols:
                 df["techgroup"] = df["techname"]
             if not all(c in df.columns for c in mapping.xl_cols):
-                missing = set(mapping.xl_cols) - set(df.columns)
+                missing = set(mapping.xl_cols).difference(df.columns)
                 logger.warning(
                     f"Cannot produce table {mapping.times_name} because"
                     f" {mapping.xl_name} does not contain the required columns"
@@ -347,7 +347,7 @@ def produce_times_tables(
                     continue
                 result[mapping.times_name] = df
 
-    unused_tables = set(input.keys()) - used_tables
+    unused_tables = set(input.keys()).difference(used_tables)
     if len(unused_tables) > 0:
         logger.warning(
             f"{len(unused_tables)} unused tables: {', '.join(sorted(unused_tables))}"

--- a/xl2times/config/times-info.json
+++ b/xl2times/config/times-info.json
@@ -1619,7 +1619,7 @@
       "YEAR",
       "PRC",
       "CG",
-      "CG",
+      "CG2",
       "TS"
     ],
     "mapping": [
@@ -1627,7 +1627,7 @@
       "year",
       "process",
       "other_indexes",
-      "other_indexes",
+      "commodity",
       "timeslice"
     ]
   },

--- a/xl2times/config/times-info.json
+++ b/xl2times/config/times-info.json
@@ -3295,11 +3295,11 @@
     "indexes": [
       "REG",
       "PRC",
-      "PRC"
+      "PRC2"
     ],
     "mapping": [
       "region",
-      "process",
+      "other_indexes",
       "process"
     ]
   },

--- a/xl2times/config/times-info.json
+++ b/xl2times/config/times-info.json
@@ -2017,14 +2017,14 @@
     "indexes": [
       "ALL_R",
       "COM",
-      "ALL_R",
-      "COM"
+      "REG2",
+      "COM2"
     ],
     "mapping": [
       "region",
       "commodity",
-      "region",
-      "commodity"
+      "region2",
+      "commodity2"
     ]
   },
   {
@@ -2035,18 +2035,18 @@
       "YEAR",
       "PRC",
       "COM",
-      "ALL_R",
-      "COM",
-      "TS"
+      "REG2",
+      "COM2",
+      "TS2"
     ],
     "mapping": [
       "region",
       "year",
       "process",
       "commodity",
-      "region",
-      "commodity",
-      "timeslice"
+      "region2",
+      "commodity2",
+      "timeslice2"
     ]
   },
   {
@@ -2059,7 +2059,7 @@
       "COM",
       "TS",
       "IE",
-      "COM",
+      "COM2",
       "IO"
     ],
     "mapping": [
@@ -2069,7 +2069,7 @@
       "commodity",
       "timeslice",
       "other_indexes",
-      "commodity",
+      "commodity2",
       "other_indexes"
     ]
   },

--- a/xl2times/config/veda-attr-defaults.json
+++ b/xl2times/config/veda-attr-defaults.json
@@ -646,6 +646,12 @@
   },
   "FLO_FUNC": {
     "defaults": {
+      "commodity": [
+        "commodity-in",
+        "commodity-out",
+        "commodity-in-aux",
+        "commodity-out-aux"
+      ],
       "ts-level": "ANNUAL"
     }
   },

--- a/xl2times/config/veda-attr-defaults.json
+++ b/xl2times/config/veda-attr-defaults.json
@@ -889,7 +889,16 @@
     },
     "times-attribute": "NCAP_PKCNT"
   },
+  "PEAK(CON)": {
+    "defaults": {
+      "ts-level": "ANNUAL"
+    },
+    "times-attribute": "NCAP_PKCNT"
+  },
   "PKCNT": {
+    "defaults": {
+      "ts-level": "ANNUAL"
+    },
     "times-attribute": "NCAP_PKCNT"
   },
   "PKCOI": {

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -318,6 +318,8 @@ class Config:
     times_sets: dict[str, list[str]]
     # Switch to prevent overwriting of I/E settings in BASE and SubRES
     ie_override_in_syssettings: bool = False
+    # Switch to include dummy imports in the model
+    include_dummy_imports: bool = True
 
     def __init__(
         self,

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2312,8 +2312,6 @@ def _match_wildcards(
         Mapping of column names to sets.
     dictionary
         Dictionary of process sets to match against.
-    matcher
-        Matching function to use, e.g. get_matching_processes or get_matching_commodities.
     result_col
         Name of the column to store the matched results in.
     explode
@@ -2343,9 +2341,8 @@ def _match_wildcards(
         .drop(columns=wild_cols)
     )
 
-    print(f"df: {df}")
-
-    # TODO TFM_UPD has existing (but empty) 'process' and 'commodity' columns. Is it ok to drop existing columns here?
+    # Pre-existing 'process' and 'commodity' are handled during renaming.
+    # The below should not be necessary, but is left just in case.
     if f"{result_col}_old" in df.columns:
         if not df[f"{result_col}_old"].isna().all():
             logger.warning(

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1829,7 +1829,6 @@ def generate_dummy_processes(
     config: Config,
     tables: list[EmbeddedXlTable],
     model: TimesModel,
-    include_dummy_processes=True,
 ) -> list[EmbeddedXlTable]:
     """Define dummy processes and specify default cost data for them to ensure that a
     TIMES model can always be solved.
@@ -1838,7 +1837,7 @@ def generate_dummy_processes(
     Significant cost is usually associated with the activity of these processes to
     ensure that they are used as a last resort
     """
-    if include_dummy_processes:
+    if config.include_dummy_imports:
         # TODO: Activity units below are arbitrary. Suggest Veda devs not to have any.
         dummy_processes = [
             ["IMP", "IMPNRGZ", "Dummy Import of NRG", "PJ", "", "NRG"],
@@ -1865,7 +1864,7 @@ def generate_dummy_processes(
         process_data_specs = process_declarations[["process", "description"]].copy()
         # Use this as default activity cost for dummy processes
         # TODO: Should this be included in settings instead?
-        process_data_specs["ACTCOST"] = 1111
+        process_data_specs["ACTCOST"] = ""
 
         tables.append(
             EmbeddedXlTable(

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2152,12 +2152,14 @@ def process_transform_availability(
 
 
 def filter_by_pattern(df: DataFrame, pattern: str) -> set[str]:
-    """Filter dataframe index by a regex pattern. Return a set of corresponding items."""
+    """Filter dataframe index by a pattern specifying which items to include and/or exclude.
+    Return a set of corresponding items from the first (and only) column in the dataframe.
+    """
     map = {"include": utils.create_regexp, "exclude": utils.create_negative_regexp}
     sets = dict()
     for action, regex_maker in map.items():
         sets[action] = set(
-            df.filter(regex=regex_maker(pattern), axis="index").iloc[:, 0].to_list()
+            df.filter(regex=regex_maker(pattern), axis="index").iloc[:, 0]
         )
 
     return sets["include"].difference(sets["exclude"])

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1862,8 +1862,7 @@ def generate_dummy_processes(
         )
 
         process_data_specs = process_declarations[["process", "description"]].copy()
-        # Use this as default activity cost for dummy processes
-        # TODO: Should this be included in settings instead?
+        # Provide an empty value in case an upd table is used to provide data
         process_data_specs["ACTCOST"] = ""
 
         tables.append(

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -533,7 +533,7 @@ def process_flexible_import_tables(
         if any(index):
             for attr in df["attribute"][index].unique():
                 i = index & (df["attribute"] == attr)
-                parts = attr.split("~")
+                parts = [part.strip() for part in attr.split("~")]
                 for value in parts:
                     colname, typed_value = _get_colname(value, legal_values)
                     if colname is None:
@@ -692,7 +692,7 @@ def process_user_constraint_tables(
         for attr in df["attribute"].unique():
             if "~" in attr:
                 i = df["attribute"] == attr
-                parts = attr.split("~")
+                parts = [part.strip() for part in attr.split("~")]
                 for value in parts:
                     colname, typed_value = _get_colname(value, legal_values)
                     if colname is None:

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2163,7 +2163,7 @@ def filter_by_pattern(df: DataFrame, pattern: str) -> set[str]:
             df.filter(regex=regex_maker(pattern), axis="index").iloc[:, 0].to_list()
         )
 
-    return sets["include"] - sets["exclude"]
+    return sets["include"].difference(sets["exclude"])
 
 
 def get_matching_items(

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -75,7 +75,7 @@ def remove_comment_rows(
 
 
 def _remove_df_comment_rows(
-    df: pd.DataFrame,
+    df: DataFrame,
     comment_chars: dict[str, list],
 ) -> None:
     """Modify a dataframe in-place by deleting rows with cells starting with symbols
@@ -1328,7 +1328,7 @@ def generate_commodity_groups(
     # Add columns for the number of IN/OUT commodities of each type
     _count_comm_group_vectorised(comm_groups)
 
-    def name_comm_group(df):
+    def name_comm_group(df: pd.Series) -> str | None:
         """Generate the name of a commodity group based on the member count."""
         if df["commoditygroup"] > 1:
             return df["process"] + "_" + df["csets"] + df["io"][:1]
@@ -1373,7 +1373,7 @@ def generate_commodity_groups(
     return tables
 
 
-def _count_comm_group_vectorised(comm_groups: pd.DataFrame) -> None:
+def _count_comm_group_vectorised(comm_groups: DataFrame) -> None:
     """Store the number of IN/OUT commodities of the same type per Region and Process in
     CommodityGroup. `comm_groups` is modified in-place.
 
@@ -1392,8 +1392,8 @@ def _count_comm_group_vectorised(comm_groups: pd.DataFrame) -> None:
 
 
 def _process_comm_groups_vectorised(
-    comm_groups: pd.DataFrame, csets_ordered_for_pcg: list[str]
-) -> pd.DataFrame:
+    comm_groups: DataFrame, csets_ordered_for_pcg: list[str]
+) -> DataFrame:
     """Sets the first commodity group in the list of csets_ordered_for_pcg as the
     default pcg for each region/process/io combination, but setting the io="OUT" subset
     as default before "IN".
@@ -1957,6 +1957,7 @@ def process_transform_table_variants(
                 and "*" not in x
                 and "," not in x
                 and "?" not in x
+                and "_" not in x
             )
         )
 
@@ -2186,8 +2187,8 @@ def get_matching_items(
     return matching_items
 
 
-def df_indexed_by_col(df, col):
-    # Set df index using an existing column; make index is uppercase
+def df_indexed_by_col(df: DataFrame, col: str) -> DataFrame:
+    """Set df index using an existing column; make index uppercase."""
     df = df.dropna().drop_duplicates()
     index = df[col].str.upper()
     df = df.set_index(index).rename_axis("index")
@@ -2199,7 +2200,7 @@ def df_indexed_by_col(df, col):
 
 def generate_topology_dictionary(
     tables: dict[str, DataFrame], model: TimesModel
-) -> dict[str, pd.Series]:
+) -> dict[str, DataFrame]:
     # We need to be able to fetch processes based on any combination of name, description, set, comm-in, or comm-out
     # So we construct tables whose indices are names, etc. and use pd.filter
 
@@ -2296,12 +2297,12 @@ def process_wildcards(
 
 
 def _match_wildcards(
-    df: pd.DataFrame,
+    df: DataFrame,
     col_map: dict[str, str],
-    dictionary: dict[str, pd.Series],
+    dictionary: dict[str, DataFrame],
     result_col: str,
     explode: bool = False,
-) -> pd.DataFrame:
+) -> DataFrame:
     """Match wildcards in the given table using the given process map and dictionary.
 
     Parameters

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2154,13 +2154,16 @@ def process_transform_availability(
     return result
 
 
-def filter_by_pattern(df: pd.Series, pattern: str) -> pd.Series:
+def filter_by_pattern(df: DataFrame, pattern: str) -> pd.Series:
     """Filter dataframe index by a regex pattern."""
     # Duplicates can be created when a process has multiple commodities that match the pattern
     df = df.filter(regex=utils.create_regexp(pattern), axis="index").drop_duplicates()
-    exclude = df.filter(regex=utils.create_negative_regexp(pattern), axis="index").index
+    exclude_values = df.filter(
+        regex=utils.create_negative_regexp(pattern), axis="index"
+    )
+    exclude = df.iloc[:, 0].isin(set(exclude_values.iloc[:, 0].to_list()))
 
-    return df.drop(exclude)
+    return df[~exclude]
 
 
 def intersect(acc: pd.Series | None, df: pd.Series) -> pd.Series | None:

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2017,6 +2017,8 @@ def process_transform_table_variants(
                 value_name="value",
                 ignore_index=False,
             )
+            # Convert the attribute column to uppercase
+            df["attribute"] = df["attribute"].str.upper()
             result.append(
                 replace(table, dataframe=df, tag=Tag(tag.value.split("-")[0]))
             )

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -2454,6 +2454,7 @@ def eval_and_update(table: DataFrame, rows_to_update: pd.Index, new_value: str) 
     which can be a update formula like `*2.3`.
     """
     if isinstance(new_value, str) and new_value[0] in {"*", "+", "-", "/"}:
+        # Do not perform arithmetic operations on rows with i/e options
         if "year" in table.columns:
             rows_to_update = rows_to_update.intersection(
                 table.index[table["year"] != 0]

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1,7 +1,6 @@
 import re
 import time
 from collections import defaultdict
-from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import replace
 from functools import reduce
@@ -2183,9 +2182,6 @@ def get_matching_items(
             filtered = filter_by_pattern(item_set, pattern)
             matching_items = intersect(matching_items, filtered)
 
-    if matching_items is not None and any(matching_items.duplicated()):
-        raise ValueError("duplicated")
-
     return matching_items
 
 
@@ -2284,7 +2280,6 @@ def process_wildcards(
                         df,
                         item_map,
                         dictionary,
-                        get_matching_items,
                         item_type,
                         explode=False,
                     )
@@ -2303,7 +2298,6 @@ def _match_wildcards(
     df: pd.DataFrame,
     col_map: dict[str, str],
     dictionary: dict[str, pd.Series],
-    matcher: Callable,
     result_col: str,
     explode: bool = False,
 ) -> pd.DataFrame:
@@ -2337,7 +2331,7 @@ def _match_wildcards(
 
     # match all the wildcards columns against the dictionary names
     matches = unique_filters.apply(
-        lambda row: matcher(row, dictionary, col_map), axis=1
+        lambda row: get_matching_items(row, dictionary, col_map), axis=1
     )
 
     matches = matches.to_list()

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -3082,6 +3082,14 @@ def fix_topology(
     if Tag.tfm_ava in tables:
         modules_with_ava = list(tables[Tag.tfm_ava]["module_name"].unique())
         updates = tables[Tag.tfm_ava].explode("process", ignore_index=True)
+        # Ensure valid combinations of process / module_name
+        updates = updates.merge(
+            model.processes[["process", "module_name"]].drop_duplicates(),
+            how="inner",
+            on=["process", "module_name"],
+        )
+        # Update tfm_ava
+        tables[Tag.tfm_ava] = updates
         # Overwrite with the last value for each process/region pair
         updates = updates.drop_duplicates(
             subset=[col for col in updates.columns if col != "value"], keep="last"

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -261,8 +261,10 @@ def create_regexp(pattern: str, combined: bool = True) -> str:
     pattern = pattern.replace(",", r"$|^")
     if len(pattern) == 0:
         return r".*"  # matches everything
-    # Substite VEDA wildcards with regex patterns; escape metacharacters
-    for substition in ((".", "\\."), ("*", ".*"), ("?", ".")):
+    # Substite VEDA wildcards with regex patterns; escape metacharacters.
+    # ("_", ".") and ("[.]", "_") are meant to apply one after another to handle
+    # the usage of "_" equivalent to "?" and "[_]" as literal "_".
+    for substition in ((".", "\\."), ("_", "."), ("[.]", "_"), ("*", ".*"), ("?", ".")):
         old, new = substition
         pattern = pattern.replace(old, new)
     # Do not match substrings

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -264,8 +264,8 @@ def create_regexp(pattern: str, combined: bool = True) -> str:
     # Substite VEDA wildcards with regex patterns; escape metacharacters.
     # ("_", ".") and ("[.]", "_") are meant to apply one after another to handle
     # the usage of "_" equivalent to "?" and "[_]" as literal "_".
-    for substition in [(".", "\\."), ("_", "."), ("[.]", "_"), ("*", ".*"), ("?", ".")]:
-        old, new = substition
+    substitute = [(".", "\\."), ("_", "."), ("[.]", "_"), ("*", ".*"), ("?", ".")]
+    for old, new in substitute:
         pattern = pattern.replace(old, new)
     # Do not match substrings
     pattern = rf"^{pattern}$"

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -261,8 +261,8 @@ def create_regexp(pattern: str, combined: bool = True) -> str:
     pattern = pattern.replace(",", r"$|^")
     if len(pattern) == 0:
         return r".*"  # matches everything
-    # Handle substite VEDA wildcards with regex patterns
-    for substition in (("*", ".*"), ("?", ".")):
+    # Substite VEDA wildcards with regex patterns; escape metacharacters
+    for substition in ((".", "\\."), ("*", ".*"), ("?", ".")):
         old, new = substition
         pattern = pattern.replace(old, new)
     # Do not match substrings

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -264,7 +264,7 @@ def create_regexp(pattern: str, combined: bool = True) -> str:
     # Substite VEDA wildcards with regex patterns; escape metacharacters.
     # ("_", ".") and ("[.]", "_") are meant to apply one after another to handle
     # the usage of "_" equivalent to "?" and "[_]" as literal "_".
-    for substition in ((".", "\\."), ("_", "."), ("[.]", "_"), ("*", ".*"), ("?", ".")):
+    for substition in [(".", "\\."), ("_", "."), ("[.]", "_"), ("*", ".*"), ("?", ".")]:
         old, new = substition
         pattern = pattern.replace(old, new)
     # Do not match substrings


### PR DESCRIPTION
This PR makes various fixes, including:
- exclude i/e options from arithmetic operations
- move dummy import switch to Config and remove default cost
- populate default values for limtype and timeslice in uc_t
- capitalise some attribute names upon upon transforming tfm table variants
- modify mappings for PRC_REFIT, FLO_FUNC, NCAP_PKCNT, etc.
- fix type errors
- improve pattern processing and close #275 
- simplify the logics behind processing of wildcards