### PR TITLE
Clean up logging, to make less confusing for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After installation, run the following command to see the basic usage and availab
 xl2times --help
 ```
 
-Here is an example invocation to convert the Demo 1 model into DD (you need to have the benchmarks set up, see [below](#running-benchmarks)):
+Here is an example invocation to convert the Demo 1 model into DD (you need to have the benchmarks set up, see the "Running Benchmarks" section below):
 ```sh
 xl2times benchmarks/xlsx/DemoS_001/
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ After installation, run the following command to see the basic usage and availab
 xl2times --help
 ```
 
+Here is an example invocation to convert the Demo 1 model into DD (you need to have the benchmarks set up, see [below](#running-benchmarks)):
+```sh
+xl2times benchmarks/xlsx/DemoS_001/
+```
+Note that by default, the tool puts the produced output DD files into a directory called `output/` in the current working directory. This behavior can be changed using the `--output_dir /path/to/desired/output/` argument.
+
+> **Note**: If you are running a huge model, and it looks like nothing is happening, try adding a `-v` or `--verbose` argument to see more detailed logs, inlcuding a message when each intermediate transform is completed.
+
 If the tool is installed on Windows, the above commands should be prefixed by `python -m`.
 
 ## Documentation
@@ -142,10 +150,10 @@ If you have a large increase in runtime, a decrease in correct rows or fewer row
 If your change is causing regressions on one of the benchmarks, a useful way to debug and find the difference is to run the tool in verbose mode and compare the intermediate tables. For example, if your branch has regressions on Demo 1:
 ```bash
 # First, on the `main` branch:
-xl2times benchmarks/xlsx/DemoS_001 --output_dir benchmarks/out/DemoS_001-all --ground_truth_dir benchmarks/csv/DemoS_001-all --verbose > before 2>&1
+xl2times benchmarks/xlsx/DemoS_001 --output_dir benchmarks/out/DemoS_001-all --ground_truth_dir benchmarks/csv/DemoS_001-all -v -v > before 2>&1
 # Then, on your branch:
 git checkout my-branch-name
-xl2times benchmarks/xlsx/DemoS_001 --output_dir benchmarks/out/DemoS_001-all --ground_truth_dir benchmarks/csv/DemoS_001-all --verbose > after 2>&1
+xl2times benchmarks/xlsx/DemoS_001 --output_dir benchmarks/out/DemoS_001-all --ground_truth_dir benchmarks/csv/DemoS_001-all -v -v > after 2>&1
 # And then compare the files `before` and `after`
 code -d before after
 ```

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,7 +10,7 @@ from xl2times.transforms import (
     process_map,
 )
 
-logger = utils.get_logger()
+utils.setup_logger(None)
 
 pd.set_option("display.max_rows", 20)
 pd.set_option("display.max_columns", 20)
@@ -28,7 +28,9 @@ class TestTransforms:
             }
         )
         df2 = transforms.explode_process_commodity_cols(
-            None, {"name": df.copy()}, None  # pyright: ignore
+            None,  # pyright: ignore
+            {"name": df.copy()},
+            None,  # pyright: ignore
         )
         correct = DataFrame(
             {

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -215,8 +215,9 @@ def run_benchmark(
         args += ["--include_dummy_imports"]
     if "regions" in benchmark:
         args.extend(["--regions", benchmark["regions"]])
-    if verbose:
-        args.append("--verbose")
+    # TODO this needs to be uncommented after PR #306 is merged in, otherwise CI will fail
+    # if verbose:
+    #     args.append("--verbose")
     if "inputs" in benchmark:
         args.extend(path.join(xl_folder, b) for b in benchmark["inputs"])
     else:

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -21,7 +21,7 @@ from xl2times.__main__ import parse_args, run
 from xl2times.dd_to_csv import main
 from xl2times.utils import max_workers
 
-logger = utils.get_logger()
+logger = utils.get_logger(0)
 
 
 def parse_result(output: str) -> tuple[float, int, int]:

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -215,6 +215,8 @@ def run_benchmark(
         args += ["--include_dummy_imports"]
     if "regions" in benchmark:
         args.extend(["--regions", benchmark["regions"]])
+    if verbose:
+        args.append("--verbose")
     if "inputs" in benchmark:
         args.extend(path.join(xl_folder, b) for b in benchmark["inputs"])
     else:

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -14,14 +14,13 @@ from typing import Any
 import git
 import pandas as pd
 import yaml
+from loguru import logger
 from tabulate import tabulate
 
 from xl2times import utils
 from xl2times.__main__ import parse_args, run
 from xl2times.dd_to_csv import main
 from xl2times.utils import max_workers
-
-logger = utils.get_logger(0)
 
 
 def parse_result(output: str) -> tuple[float, int, int]:
@@ -431,6 +430,8 @@ def run_all_benchmarks(
 
 
 if __name__ == "__main__":
+    utils.setup_logger(1)
+
     args_parser = argparse.ArgumentParser()
     args_parser.add_argument(
         "benchmarks_yaml",

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -175,8 +175,10 @@ def convert_xl_to_times(
         )
         logger.opt(raw=True).debug(_log_sep)
         # Way to conditionally evaluate the table dump only on debug log level
-        # https://github.com/Delgan/loguru/issues/402#issuecomment-2028011786
-        logger.opt(lazy=True, raw=True).debug(_all_table_dump(output))
+        # https://loguru.readthedocs.io/en/stable/overview.html#lazy-evaluation-of-expensive-functions
+        logger.opt(lazy=True).debug(
+            "All tables:\n{dump}", dump=lambda: _all_table_dump(output)
+        )
         input = output
     assert isinstance(output, dict)
 

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -495,6 +495,8 @@ def run(args: argparse.Namespace) -> str | None:
     -------
         comparison with ground-truth string if `ground_truth_dir` is provided, else None.
     """
+    utils.setup_logger(args.verbose)
+
     config = Config(
         "times_mapping.txt",
         "times-info.json",
@@ -506,8 +508,6 @@ def run(args: argparse.Namespace) -> str | None:
     )
 
     model = TimesModel()
-
-    logger = utils.get_logger(args.verbose)
 
     if not isinstance(args.input, list) or len(args.input) < 1:
         logger.critical(f"expected at least 1 input. Got {args.input}")
@@ -624,7 +624,7 @@ def parse_args(arg_list: None | list[str]) -> argparse.Namespace:
         "-v",
         "--verbose",
         action="count",
-        help="Verbosity. Multiple `-v`s increase the log level. Can also be set on the command line by setting the environment variable `LOGURU_LEVEL`. Available levels are `TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`, and `CRITICAL`. Default is `WARNING`",
+        help="Verbosity. Multiple `-v`s increase the log level. Can also be set on the command line by setting the environment variable `LOGURU_LEVEL`. Available levels are `TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`, and `CRITICAL`. Default is `SUCCESS`",
     )
     args = args_parser.parse_args(arg_list)
     return args

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -130,7 +130,14 @@ class DataModule(str, Enum):
     def module_name(cls, path: str) -> str | None:
         module_type = cls.determine_type(path)
         match module_type:
-            case DataModule.base | DataModule.sets | DataModule.lma | DataModule.demand | DataModule.trade | DataModule.syssettings:
+            case (
+                DataModule.base
+                | DataModule.sets
+                | DataModule.lma
+                | DataModule.demand
+                | DataModule.trade
+                | DataModule.syssettings
+            ):
                 return module_type.name.upper()
             case DataModule.subres:
                 return re.sub(
@@ -565,9 +572,7 @@ class Config:
                     dropped.append(line)
 
         if len(dropped) > 0:
-            logger.warning(
-                f"Dropping {len(dropped)} mappings that are not yet complete"
-            )
+            logger.info(f"Dropping {len(dropped)} mappings that are not yet complete")
         return mappings
 
     @staticmethod

--- a/xl2times/datatypes.py
+++ b/xl2times/datatypes.py
@@ -602,8 +602,8 @@ class Config:
         tags = {to_tag(tag_info["tag_name"]) for tag_info in veda_tags_info}
         for tag in Tag:
             if tag not in tags:
-                logger.warning(
-                    f"datatypes.Tag has an unknown Tag {tag} not in {veda_tags_file}"
+                logger.info(
+                    f"WARNING: datatypes.Tag has an unknown Tag {tag} not in {veda_tags_file}"
                 )
 
         valid_column_names = {}

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -354,7 +354,7 @@ def normalize_column_aliases(
                 columns=config.column_aliases[tag], errors="ignore"
             )
         else:
-            logger.warning(f"could not find {tag.value} in config.column_aliases")
+            logger.info(f"WARNING: could not find {tag.value} in config.column_aliases")
         if len(set(table.dataframe.columns)) > len(table.dataframe.columns):
             raise ValueError(
                 f"Table has duplicate column names (after normalization): {table}"

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -421,7 +421,7 @@ def merge_tables(
                     for _, row in df[~index].iterrows():
                         region, sets, process = row[["region", "sets", "process"]]
                         logger.warning(
-                            f"WARNING: Unknown process set {sets} specified for process {process}"
+                            f"Unknown process set {sets} specified for process {process}"
                             f" in region {region}. The record will be dropped."
                         )
                 # Exclude records with non-TIMES sets
@@ -439,7 +439,6 @@ def apply_tag_specified_defaults(
     tables: list[EmbeddedXlTable],
     model: TimesModel,
 ) -> list[EmbeddedXlTable]:
-
     return [utils.apply_composite_tag(t) for t in tables]
 
 
@@ -2228,8 +2227,7 @@ def process_wildcards(
     }
 
     for tag in tags:
-        if tag in tqdm(tables, desc=f"Processing wildcards in {tag.value} tables"):
-
+        if tag in tables:
             start_time = time.time()
             df = tables[tag]
 
@@ -2337,7 +2335,6 @@ def query(
     val: int | float | None,
     module: str | list[str] | None,
 ) -> pd.Index:
-
     query_fields = {
         "process": process,
         "commodity": commodity,
@@ -3199,7 +3196,6 @@ def apply_final_fixup(
     tables: dict[str, DataFrame],
     model: TimesModel,
 ) -> dict[str, DataFrame]:
-
     veda_ire_sets = model.custom_sets
     reg_com_flows = model.topology[["region", "process", "commodity"]].copy()
     reg_com_flows.drop_duplicates(inplace=True, ignore_index=True)


### PR DESCRIPTION
This PR makes the following changes:
- Adds a `-v` argument that can be chained (e.g. `-v -v`) in order to increase log verbosity levels
- Change the default log level to SUCCESS, so that the INFO messages that are meant for us devs don't confuse users
- Adds instructions to the README to tell users how to change log levels, especially if they're concerned that the tool isn't doing anything 😅 
- Changes a bunch of WARNING messages to INFO, as they aren't meant to be seen by users
- Changes the way `loguru` is set up (setting `os.environ["LOGURU_LEVEL"] = ...` in the code doesn't seem to have an effect after arguments are parsed, which is when we know the desired log level)