### PR TITLE
Reduce warnings

### DIFF
--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -305,7 +305,7 @@ def produce_times_tables(
     mappings = [
         m
         for m in config.times_xl_maps
-        if m.times_name in defined_pars or m.xl_name not in par_tables
+        if m.xl_name not in par_tables or m.filter_rows.get("attribute") in defined_pars
     ]
 
     def keep_last_by_file_order(df):

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -336,8 +336,7 @@ def produce_times_tables(
                     # TODO break this loop and continue outer loop?
                 filter = set(x.lower() for x in (filter_val,))
                 i = df[filter_col].str.lower().isin(filter)
-                # Ensure that df is not a view, so that we can modify it further on
-                df = df[i].copy()
+                df = df[i]
             if not all(c in df.columns for c in mapping.xl_cols):
                 missing = set(mapping.xl_cols).difference(df.columns)
                 logger.warning(
@@ -346,6 +345,8 @@ def produce_times_tables(
                     f" - {', '.join(missing)}"
                 )
             else:
+                # Ensure that df is not a view
+                df = df.reset_index(drop=True)
                 # Excel columns can be duplicated into multiple Times columns
                 for times_col, xl_col in mapping.col_map.items():
                     df[times_col] = df[xl_col]

--- a/xl2times/__main__.py
+++ b/xl2times/__main__.py
@@ -336,7 +336,8 @@ def produce_times_tables(
                     # TODO break this loop and continue outer loop?
                 filter = set(x.lower() for x in (filter_val,))
                 i = df[filter_col].str.lower().isin(filter)
-                df = df.loc[i, :]
+                # Ensure that df is not a view, so that we can modify it further on
+                df = df[i].copy()
             if not all(c in df.columns for c in mapping.xl_cols):
                 missing = set(mapping.xl_cols).difference(df.columns)
                 logger.warning(

--- a/xl2times/config/times-info.json
+++ b/xl2times/config/times-info.json
@@ -3142,18 +3142,6 @@
     ]
   },
   {
-    "name": "PRC_DSCNCAP",
-    "gams-cat": "md-set",
-    "indexes": [
-      "R",
-      "P"
-    ],
-    "mapping": [
-      "region",
-      "process"
-    ]
-  },
-  {
     "name": "PRC_FOFF",
     "gams-cat": "md-set",
     "indexes": [

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1093,6 +1093,7 @@ def complete_dictionary(
     tables: dict[str, DataFrame],
     model: TimesModel,
 ) -> dict[str, DataFrame]:
+    tables = dict()
     for k, v in [
         ("AllRegions", model.all_regions),
         ("Regions", model.internal_regions),

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1294,12 +1294,13 @@ def include_cgs_in_topology(
     """Include commodity groups in model topology."""
     # Veda determines default PCG based on predetermined order and presence of OUT/IN commodity
     columns = ["region", "process", "primarycg"]
-    reg_prc_pcg = tables[Tag.fi_process][columns].drop_duplicates(keep="last")
-
+    i = tables[Tag.fi_process]["primarycg"].isin(default_pcg_suffixes)
     # DataFrame with Veda PCGs specified in the process declaration tables
-    reg_prc_veda_pcg = reg_prc_pcg.loc[
-        reg_prc_pcg["primarycg"].isin(default_pcg_suffixes)
-    ]
+    reg_prc_veda_pcg = (
+        tables[Tag.fi_process]
+        .loc[i, columns]
+        .drop_duplicates(keep="last", ignore_index=True)
+    )
 
     # Extract commodities and their sets by region
     columns = ["region", "csets", "commodity"]

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1792,7 +1792,7 @@ def generate_dummy_processes(
         for col, value in additional_cols.items():
             process_declarations[col] = value
 
-        process_data_specs = process_declarations[["process", "description"]]
+        process_data_specs = process_declarations[["process"]].copy()
         # Provide an empty value in case an upd table is used to provide data
         process_data_specs["ACTCOST"] = ""
 


### PR DESCRIPTION
- Address pandas' 'A value is trying to be set on a copy of a slice from a DataFrame.'
- Do not print a warning if a table for a not specified parameter can not be produced
- Do not include the original tables when determining the unused tables