### PR TITLE
Update notebook demo to run on Colab; add explanatory text

### DIFF
--- a/tests/notebook-demo.ipynb
+++ b/tests/notebook-demo.ipynb
@@ -1,183 +1,312 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "65179b0a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from os import path\n",
-    "\n",
-    "import gdx2py\n",
-    "from gamspy_base import directory\n",
-    "\n",
-    "import xl2times.main as xt\n",
-    "from xl2times.utils import run_gams, setup_logger"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "a93b7f6a",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: gdx2py in /scratch/htc/skrishna/xl2times/.venv/lib/python3.12/site-packages (2.2.0)\n",
-      "Requirement already satisfied: gamspy-base in /scratch/htc/skrishna/xl2times/.venv/lib/python3.12/site-packages (49.6.1)\n",
-      "Requirement already satisfied: gamsapi>=47 in /scratch/htc/skrishna/xl2times/.venv/lib/python3.12/site-packages (from gdx2py) (49.6.1)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install gdx2py gamspy-base"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "f4e18642",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/scratch/htc/skrishna/xl2times/xl2times/transforms.py:1276: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value 'EOH' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
-      "  df.loc[\n",
-      "Applying transformations from ~TFM_UPD in SYSSETTINGS: 100%|██████████| 2/2 [00:00<00:00, 160.50it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "setup_logger(level=0)\n",
-    "input_dir = \"../benchmarks/xlsx/DemoS_003/\"\n",
-    "output_dir = \"../benchmarks/out/DemoS_003-all/\"\n",
-    "times_dir = \"../TIMES_model/\"\n",
-    "\n",
-    "model, config = xt.read_xl([input_dir], regions=\"\", include_dummy_imports=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "1c03f705",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Inspect some key parameters in the solution\n",
-    "def inspect_solution():\n",
-    "    with gdx2py.GdxFile(path.join(output_dir, \"scenario.gdx\"), gams_dir=directory) as g:\n",
-    "        print(g[\"REG_OBJ\"].values())\n",
-    "        print(g[\"PAR_COMPRDL\"].values())\n",
-    "        print(g[\"EQE_COMPRD\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "54dd1832",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "169    0.9\n",
-      "Name: value, dtype: object\n",
-      "\u001b[36m2025-06-04 19:38:08.813\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mExcel files successfully converted to DD and written to ../benchmarks/out/DemoS_003-all/\u001b[0m\n"
-     ]
+      "cell_type": "markdown",
+      "id": "11c66bd6",
+      "metadata": {},
+      "source": [
+        "# Running TIMES Models using Python Notebooks\n",
+        "\n",
+        "This is a demonstration of how to use Python (Jupyter) notebooks to define, run, modify, and analyze TIMES model scenarios.\n",
+        "\n",
+        "Using `xl2times`'s new `TimesModel` API, one can run model scenarios in an interactive, reproducible, self-documenting, and programmable way."
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m2025-06-04 19:38:12.094\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mRan GAMS successfully on ../benchmarks/out/DemoS_003-all/:\n",
-      "*** Status: Normal completion--- Job scenario.run Stop 06/04/25 19:38:12 elapsed 0:00:02.820\u001b[0m\n",
-      "dict_values([3195557.668833001])\n",
-      "dict_values([])\n",
-      "None\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(model.attributes.query('attribute == \"COM_IE\"')[\"value\"])\n",
-    "tables = xt.to_tables(config, model)\n",
-    "xt.write_dd_files(tables, config, output_dir)\n",
-    "\n",
-    "run_gams(times_dir, output_dir)\n",
-    "\n",
-    "inspect_solution()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "f8996f37",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "169    0.95\n",
-      "Name: value, dtype: object\n",
-      "\u001b[36m2025-06-04 19:38:12.471\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mExcel files successfully converted to DD and written to ../benchmarks/out/DemoS_003-all/\u001b[0m\n"
-     ]
+      "cell_type": "markdown",
+      "id": "da7a2025",
+      "metadata": {},
+      "source": [
+        "## Setup the Demo on Colab\n",
+        "\n",
+        "This section is not neccessary if you have installed `xl2times` and the Demo models on your local machine."
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m2025-06-04 19:38:12.828\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mRan GAMS successfully on ../benchmarks/out/DemoS_003-all/:\n",
-      "*** Status: Normal completion--- Job scenario.run Stop 06/04/25 19:38:12 elapsed 0:00:00.324\u001b[0m\n",
-      "dict_values([3095381.6789671676])\n",
-      "dict_values([])\n",
-      "None\n"
-     ]
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "a93b7f6a",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "a93b7f6a",
+        "outputId": "8285d45b-03f7-4518-fa24-753106d1a15d"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Collecting git+https://github.com/etsap-TIMES/xl2times.git\n",
+            "  Cloning https://github.com/etsap-TIMES/xl2times.git to /tmp/pip-req-build-0ql_n06v\n",
+            "  Running command git clone --filter=blob:none --quiet https://github.com/etsap-TIMES/xl2times.git /tmp/pip-req-build-0ql_n06v\n",
+            "  Resolved https://github.com/etsap-TIMES/xl2times.git to commit c6e062d74bea0928aa6b0c23ff3b292dbecad0f9\n",
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "Collecting gdx2py\n",
+            "  Downloading GDX2py-2.2.0-py3-none-any.whl.metadata (2.7 kB)\n",
+            "Collecting gamspy-base\n",
+            "  Downloading gamspy_base-49.6.1-py3-none-manylinux_2_17_x86_64.whl.metadata (1.6 kB)\n",
+            "Collecting gamsapi>=47 (from gdx2py)\n",
+            "  Downloading gamsapi-49.6.1-cp311-cp311-manylinux_2_17_x86_64.whl.metadata (5.8 kB)\n",
+            "Requirement already satisfied: GitPython<3.2,>=3.1.31 in /usr/local/lib/python3.11/dist-packages (from xl2times==0.2.2) (3.1.44)\n",
+            "Requirement already satisfied: more-itertools in /usr/local/lib/python3.11/dist-packages (from xl2times==0.2.2) (10.7.0)\n",
+            "Requirement already satisfied: openpyxl>=3.1.3 in /usr/local/lib/python3.11/dist-packages (from xl2times==0.2.2) (3.1.5)\n",
+            "Requirement already satisfied: pandas>=2.1 in /usr/local/lib/python3.11/dist-packages (from xl2times==0.2.2) (2.2.2)\n",
+            "Requirement already satisfied: pyarrow in /usr/local/lib/python3.11/dist-packages (from xl2times==0.2.2) (18.1.0)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.11/dist-packages (from xl2times==0.2.2) (4.67.1)\n",
+            "Collecting loguru (from xl2times==0.2.2)\n",
+            "  Downloading loguru-0.7.3-py3-none-any.whl.metadata (22 kB)\n",
+            "Requirement already satisfied: gitdb<5,>=4.0.1 in /usr/local/lib/python3.11/dist-packages (from GitPython<3.2,>=3.1.31->xl2times==0.2.2) (4.0.12)\n",
+            "Requirement already satisfied: et-xmlfile in /usr/local/lib/python3.11/dist-packages (from openpyxl>=3.1.3->xl2times==0.2.2) (2.0.0)\n",
+            "Requirement already satisfied: numpy>=1.23.2 in /usr/local/lib/python3.11/dist-packages (from pandas>=2.1->xl2times==0.2.2) (2.0.2)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.11/dist-packages (from pandas>=2.1->xl2times==0.2.2) (2.9.0.post0)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas>=2.1->xl2times==0.2.2) (2025.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas>=2.1->xl2times==0.2.2) (2025.2)\n",
+            "Requirement already satisfied: smmap<6,>=3.0.1 in /usr/local/lib/python3.11/dist-packages (from gitdb<5,>=4.0.1->GitPython<3.2,>=3.1.31->xl2times==0.2.2) (5.0.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.11/dist-packages (from python-dateutil>=2.8.2->pandas>=2.1->xl2times==0.2.2) (1.17.0)\n",
+            "Downloading GDX2py-2.2.0-py3-none-any.whl (9.4 kB)\n",
+            "Downloading gamspy_base-49.6.1-py3-none-manylinux_2_17_x86_64.whl (75.2 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m75.2/75.2 MB\u001b[0m \u001b[31m9.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading gamsapi-49.6.1-cp311-cp311-manylinux_2_17_x86_64.whl (1.2 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.2/1.2 MB\u001b[0m \u001b[31m58.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading loguru-0.7.3-py3-none-any.whl (61 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m61.6/61.6 kB\u001b[0m \u001b[31m4.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hBuilding wheels for collected packages: xl2times\n",
+            "  Building wheel for xl2times (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for xl2times: filename=xl2times-0.2.2-py3-none-any.whl size=80618 sha256=fd8715b0da2e6469a2050b0e93447fe23b171cf862de113832d7dc3a94bfec08\n",
+            "  Stored in directory: /tmp/pip-ephem-wheel-cache-gaifqa2a/wheels/d4/b5/63/8fcb20cf732167e710e5117b2dc5eb8154d9972bbf164fb9c1\n",
+            "Successfully built xl2times\n",
+            "Installing collected packages: gamspy-base, loguru, gamsapi, gdx2py, xl2times\n",
+            "Successfully installed gamsapi-49.6.1 gamspy-base-49.6.1 gdx2py-2.2.0 loguru-0.7.3 xl2times-0.2.2\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install gdx2py gamspy-base git+https://github.com/etsap-TIMES/xl2times.git"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "NzERPjTHzaHI",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NzERPjTHzaHI",
+        "outputId": "71a09d8e-d429-4bcc-d751-c40c356d7ed8"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+            "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+            "100  226k  100  226k    0     0  85880      0  0:00:02  0:00:02 --:--:-- 85902\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%bash\n",
+        "# Download the Demo 3 model\n",
+        "curl 'https://drive.usercontent.google.com/download?id=10zeI0xDk4g_I1e5xFwiC7e74Z21uYgWN&export=download&authuser=0&confirm=t' -o DemoS_003.zip\n",
+        "unzip DemoS_003.zip\n",
+        "# Clone the TIMES source code\n",
+        "git clone --filter=blob:none https://github.com/etsap-TIMES/TIMES_model TIMES_model\n",
+        "pushd TIMES_model/\n",
+        "git checkout b488fb07f0899ee8b7e710c230b1a9414fa06f7d\n",
+        "popd"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "199657e6",
+      "metadata": {},
+      "source": [
+        "## Run a model scenario"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "65179b0a",
+      "metadata": {
+        "id": "65179b0a"
+      },
+      "outputs": [],
+      "source": [
+        "from os import path\n",
+        "\n",
+        "import gdx2py\n",
+        "from gamspy_base import directory\n",
+        "\n",
+        "import xl2times.main as xt\n",
+        "from xl2times.utils import run_gams, setup_logger"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "id": "f4e18642",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "f4e18642",
+        "outputId": "dcd21280-d7f5-424f-a016-6a8587ff7dce"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.11/dist-packages/xl2times/transforms.py:1276: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value 'EOH' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
+            "  df.loc[\n",
+            "Applying transformations from ~TFM_UPD in SYSSETTINGS: 100%|██████████| 2/2 [00:00<00:00, 97.03it/s]\n"
+          ]
+        }
+      ],
+      "source": [
+        "setup_logger(level=0)\n",
+        "input_dir = \"/content/DemoS_003/\"\n",
+        "output_dir = \"/content/DemoS_003-all-out/\"\n",
+        "times_dir = \"/content/TIMES_model/\"\n",
+        "\n",
+        "model, config = xt.read_xl([input_dir], regions=\"\", include_dummy_imports=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "id": "1c03f705",
+      "metadata": {
+        "id": "1c03f705"
+      },
+      "outputs": [],
+      "source": [
+        "# Inspect some key parameters in the solution\n",
+        "def inspect_solution():\n",
+        "    with gdx2py.GdxFile(path.join(output_dir, \"scenario.gdx\"), gams_dir=directory) as g:\n",
+        "        print(g[\"REG_OBJ\"].values())\n",
+        "        print(g[\"PAR_COMPRDL\"].values())\n",
+        "        print(g[\"EQE_COMPRD\"])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "id": "54dd1832",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "54dd1832",
+        "outputId": "7ae6861c-8ada-43e8-914b-da3944d54ec7"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "169    0.9\n",
+            "Name: value, dtype: object\n",
+            "\u001b[36m2025-06-07 10:16:51.921\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mExcel files successfully converted to DD and written to /content/DemoS_003-all-out/\u001b[0m\n",
+            "\u001b[36m2025-06-07 10:16:52.320\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mRan GAMS successfully on /content/DemoS_003-all-out/:\n",
+            "*** Status: Normal completion--- Job scenario.run Stop 06/07/25 10:16:52 elapsed 0:00:00.374\u001b[0m\n",
+            "dict_values([3195557.668833001])\n",
+            "dict_values([])\n",
+            "None\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model.attributes.query('attribute == \"COM_IE\"')[\"value\"])\n",
+        "tables = xt.to_tables(config, model)\n",
+        "xt.write_dd_files(tables, config, output_dir)\n",
+        "\n",
+        "run_gams(times_dir, output_dir)\n",
+        "\n",
+        "inspect_solution()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "86313300",
+      "metadata": {},
+      "source": [
+        "## Modify some assumptions and re-run the scenario\n",
+        "\n",
+        "One can think of extending this to programmatically run multiple scenarios, automatically varying a parameter from a set of options, etc."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "id": "f8996f37",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "f8996f37",
+        "outputId": "7074a1ae-89c9-483c-fe96-53248483a0b7"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "169    0.95\n",
+            "Name: value, dtype: object\n",
+            "\u001b[36m2025-06-07 10:17:51.023\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mExcel files successfully converted to DD and written to /content/DemoS_003-all-out/\u001b[0m\n",
+            "\u001b[36m2025-06-07 10:17:51.392\u001b[0m | \u001b[32m\u001b[1m SUCCESS\u001b[0m : \u001b[32m\u001b[1mRan GAMS successfully on /content/DemoS_003-all-out/:\n",
+            "*** Status: Normal completion--- Job scenario.run Stop 06/07/25 10:17:51 elapsed 0:00:00.347\u001b[0m\n",
+            "dict_values([3095381.6789671676])\n",
+            "dict_values([])\n",
+            "None\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Modify COM_IE and re-run the scenario\n",
+        "com_ie = model.attributes.query('attribute == \"COM_IE\"')\n",
+        "model.attributes.loc[com_ie.index, \"value\"] = 0.95\n",
+        "print(model.attributes.query('attribute == \"COM_IE\"')[\"value\"])\n",
+        "\n",
+        "tables = xt.to_tables(config, model)\n",
+        "xt.write_dd_files(tables, config, output_dir)\n",
+        "\n",
+        "run_gams(times_dir, output_dir)\n",
+        "\n",
+        "inspect_solution()"
+      ]
     }
-   ],
-   "source": [
-    "# Modify COM_IE and re-run the scenario\n",
-    "com_ie = model.attributes.query('attribute == \"COM_IE\"')\n",
-    "model.attributes.loc[com_ie.index, \"value\"] = 0.95\n",
-    "print(model.attributes.query('attribute == \"COM_IE\"')[\"value\"])\n",
-    "\n",
-    "tables = xt.to_tables(config, model)\n",
-    "xt.write_dd_files(tables, config, output_dir)\n",
-    "\n",
-    "run_gams(times_dir, output_dir)\n",
-    "\n",
-    "inspect_solution()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.10"
+    }
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR updates the notebook demo to work on Google colab. It also adds some text to explain what the demo is about and what else can be done (but just a sketch, please suggest how to extend/improve it!). The Demo 3 model is downloaded from a link to my drive.