### PR TITLE
Add unit tests and docstrings for create_regexp

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,6 +91,80 @@ class TestUtils:
         assert output2[0].equals(correct_result2[0]), "Dataframes should be equal"
         assert output2[1].equals(correct_result2[1]), "Series should be equal"
 
+    def test_create_regexp(self):
+        """Test VEDA wildcard pattern to regex conversion."""
+        # Basic wildcards
+        assert utils.create_regexp("Elec*") == r"^Elec.*$"
+        assert utils.create_regexp("Fuel?") == r"^Fuel.$"
+        assert utils.create_regexp("Fuel_") == r"^Fuel.$"  # _ is equivalent to ?
+
+        # Literal dots should be escaped
+        assert utils.create_regexp("1.5MW") == r"^1\.5MW$"
+        assert utils.create_regexp("coal.price") == r"^coal\.price$"
+
+        # Literal underscore using [_]
+        assert utils.create_regexp("Tech[_]1") == r"^Tech_1$"
+        assert utils.create_regexp("Heat[_]Pump") == r"^Heat_Pump$"
+
+        # Multiple wildcards
+        assert utils.create_regexp("?_*") == r"^...*$"
+        assert utils.create_regexp("Tech*[_]?") == r"^Tech.*_.$"
+
+        # Comma-separated values
+        assert utils.create_regexp("Coal,Gas") == r"^Coal$|^Gas$"
+        assert utils.create_regexp("Coal,Gas,Oil") == r"^Coal$|^Gas$|^Oil$"
+
+        # Patterns with spaces (should be stripped)
+        assert utils.create_regexp(" Coal , Gas ") == r"^Coal$|^Gas$"
+
+        # Mixed wildcards and commas
+        assert utils.create_regexp("Heat*,Cool?") == r"^Heat.*$|^Cool.$"
+
+        # Empty pattern matches everything
+        assert utils.create_regexp("") == r".*"
+
+        # Negative patterns are ignored by create_regexp
+        assert utils.create_regexp("Heat*,-HeatPump") == r"^Heat.*$"
+        assert utils.create_regexp("-Gas*,-Oil*") == r".*"
+
+        # Complex combinations
+        assert (
+            utils.create_regexp("Tech[_]?,Fuel.*,1.5*")
+            == r"^Tech_.$|^Fuel\..*$|^1\.5.*$"
+        )
+
+    def test_create_negative_regexp(self):
+        """Test negative pattern handling."""
+        # Basic negative patterns
+        assert utils.create_negative_regexp("Heat*,-HeatPump") == r"^HeatPump$"
+        assert utils.create_negative_regexp("-Gas*,-Oil*") == r"^Gas.*$|^Oil.*$"
+
+        # Single negative with wildcards
+        assert utils.create_negative_regexp("-Heat*") == r"^Heat.*$"
+        assert utils.create_negative_regexp("-Cool?") == r"^Cool.$"
+
+        # Multiple negatives with wildcards
+        assert (
+            utils.create_negative_regexp("-Heat*,-Cool?,-1.5MW")
+            == r"^Heat.*$|^Cool.$|^1\.5MW$"
+        )
+
+        # Mixed positive and negative (positives are ignored)
+        assert utils.create_negative_regexp("Coal,Gas,-Oil*") == r"^Oil.*$"
+
+        # Pattern with spaces (should be stripped)
+        assert utils.create_negative_regexp(" -Coal , -Gas ") == r"^Coal$|^Gas$"
+
+        # Empty pattern or no negatives matches nothing
+        assert utils.create_negative_regexp("") == r"^$"
+        assert utils.create_negative_regexp("Coal,Gas") == r"^$"
+
+        # Complex combinations
+        assert (
+            utils.create_negative_regexp("Tech*,-Tech[_]?,-Tech.Old")
+            == r"^Tech_.$|^Tech\.Old$"
+        )
+
 
 if __name__ == "__main__":
     TestUtils().test_explode()

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -247,7 +247,43 @@ def remove_whitespace(pattern: str) -> str:
 
 
 @functools.lru_cache(maxsize=int(1e6))
-def create_regexp(pattern: str, combined: bool = True) -> str:
+def create_regexp(pattern: str) -> str:
+    """Create a regular expression pattern that handles VEDA wildcards and comma-separated lists.
+
+    This function converts VEDA-style patterns into regular expressions, handling:
+    - Wildcards: '*' (multiple chars), '?' or '_' (single char)
+    - Literal underscores using '[_]'
+    - Comma-separated values that match any of the items
+    - Negative patterns (starting with '-') are ignored in this function,
+      but can be handled separately with create_negative_regexp().
+
+    Parameters
+    ----------
+    pattern : str
+        The VEDA pattern to convert.
+
+    Returns
+    -------
+    str
+        A regular expression pattern that matches according to VEDA rules.
+
+    Examples
+    --------
+    >>> create_regexp("Elec*")
+    '^Elec.*$'  # Matches 'Elec', 'Electric', 'Electricity', etc.
+
+    >>> create_regexp("Fuel?_Gen")
+    '^Fuel..Gen$'  # Matches 'Fuel1_Gen', 'FuelA_Gen', 'Fuel22Gen' etc.
+
+    >>> create_regexp("Tech?[_]1")
+    '^Tech._1$'  # Matches 'TechA_1', 'TechB_1' etc, treating '_' as literal
+
+    >>> create_regexp("Coal,Gas")
+    '^Coal$|^Gas$'  # Matches exactly 'Coal' or 'Gas'
+
+    >>> create_regexp("Heat*,-HeatPump")
+    '^Heat.*$'  # Matches anything starting with 'Heat', the negative 'HeatPump' pattern is ignored
+    """
     pattern = remove_whitespace(pattern)
     # Exclude negative patterns
     if has_negative_patterns(pattern):
@@ -269,11 +305,38 @@ def create_regexp(pattern: str, combined: bool = True) -> str:
 
 @functools.lru_cache(maxsize=int(1e6))
 def create_negative_regexp(pattern: str) -> str:
+    """Create a regular expression for negative patterns (those starting with '-').
+
+    This is the complementary function to create_regexp(), handling the excluded patterns.
+    When a pattern contains items starting with '-', those items become the patterns
+    to exclude from matches.
+
+    Parameters
+    ----------
+    pattern : str
+        The VEDA pattern containing negative patterns (items starting with '-')
+
+    Returns
+    -------
+    str
+        A regular expression pattern that matches only the negative patterns.
+
+    Examples
+    --------
+    >>> create_negative_regexp("Heat*,-HeatPump,-HeatWaste")
+    '^HeatPump$|^HeatWaste$'  # Creates pattern matching the excluded items
+
+    >>> create_negative_regexp("-Gas*,-Oil*")
+    '^Gas.*$|^Oil.*$'  # Matches anything starting with 'Gas' or 'Oil'
+
+    >>> create_negative_regexp("Coal,Gas")
+    '^$'  # No negative patterns, matches nothing
+    """
     pattern = remove_whitespace(pattern)
     # Exclude positive patterns
     pattern = remove_positive_patterns(pattern)
     if len(pattern) == 0:
-        pattern = r"^$"  # matches nothing
+        return r"^$"  # matches nothing
     return create_regexp(pattern)
 
 
@@ -527,7 +590,7 @@ def run_gams(times_folder: str, out_folder: str) -> None:
     """
     # Import gamspy-base in here and not at the top of the file so that xl2times doesn't depend on it
     try:
-        from gamspy_base import directory
+        from gamspy_base import directory  # pyright: ignore
     except ImportError:
         raise NotImplementedError("Package gamspy-base not installed. Cannot run GAMS.")
 

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -336,7 +336,7 @@ def create_negative_regexp(pattern: str) -> str:
     # Exclude positive patterns
     pattern = remove_positive_patterns(pattern)
     if len(pattern) == 0:
-        return r"^$"  # matches nothing
+        return r"$^"  # matches nothing
     return create_regexp(pattern)
 
 


### PR DESCRIPTION
Closes #222 

Adding tests found a little bug in the implementation! `utils.create_negative_regexp("")` was `r"^^$$"` but it should actually be a regexp that doesn't match anything, like `r"$^"`.

(My first attempt at using Copilot edit mode in VS Code to automate the more boring parts of coding!)